### PR TITLE
Update urls for Android prebuilt dependencies

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,7 @@ fn android_main(target: &str) {
         panic!("Invalid target architecture {}", target);
     };
 
-    let url = format!("https://github.com/ferjm/libgstreamer_android_gen/blob/gst1.14/out/{}.zip?raw=true",
+    let url = format!("https://github.com/servo/libgstreamer_android_gen/blob/master/out/{}.zip?raw=true",
                       lib_file_name);
     let status = Command::new("wget").args(&[&url, "-O", "lib.zip"]).status().unwrap();
     if !status.success() {

--- a/examples/android/setup.sh
+++ b/examples/android/setup.sh
@@ -1,4 +1,4 @@
-wget https://github.com/ferjm/libgstreamer_android_gen/blob/gst1.14/out/src.zip?raw=true -O src.zip
+wget https://github.com/servo/libgstreamer_android_gen/blob/master/out/src.zip?raw=true -O src.zip
 unzip src.zip -d src_
 
 cp -v src_/src/org/freedesktop/gstreamer/GStreamer.java src/app/src/main/java/org/freedesktop/gstreamer/


### PR DESCRIPTION
This is required after moving the Android deps repo to the servo org.