### PR TITLE
Fix audio render thread thread safety issues

### DIFF
--- a/src/audio/destination_node.rs
+++ b/src/audio/destination_node.rs
@@ -10,7 +10,7 @@ impl DestinationNode {
 }
 
 impl AudioNodeEngine for DestinationNode {
-    fn process(&self, inputs: Chunk, _rate: u32) -> Chunk {
+    fn process(&self, inputs: Chunk, _sample_rate: f32) -> Chunk {
         inputs
     }
 }

--- a/src/audio/gain_node.rs
+++ b/src/audio/gain_node.rs
@@ -27,7 +27,7 @@ impl AudioNodeEngine for GainNode {
     fn process(
         &self,
         mut inputs: Chunk,
-        _rate: u32,
+        _sample_rate: f32,
     ) -> Chunk {
         debug_assert!(inputs.len() == 1);
 

--- a/src/audio/graph.rs
+++ b/src/audio/graph.rs
@@ -16,7 +16,7 @@ impl AudioGraph {
         Builder::new()
             .name("AudioGraph".to_owned())
             .spawn(move || {
-                AudioGraphThread::start(receiver);
+                AudioGraphThread::start(receiver).expect("Could not start AudioGraphThread");
             })
             .unwrap();
         Self { sender }
@@ -24,8 +24,7 @@ impl AudioGraph {
 
     pub fn create_node(&self, node_type: AudioNodeType) -> usize {
         let node_id = NEXT_NODE_ID.fetch_add(1, Ordering::SeqCst);
-        let _ = self.sender
-            .send(AudioGraphThreadMsg::CreateNode(node_type));
+        let _ = self.sender.send(AudioGraphThreadMsg::CreateNode(node_type));
         node_id
     }
 

--- a/src/audio/graph.rs
+++ b/src/audio/graph.rs
@@ -13,10 +13,11 @@ pub struct AudioGraph {
 impl AudioGraph {
     pub fn new() -> Self {
         let (sender, receiver) = mpsc::channel();
+        let sender_ = sender.clone();
         Builder::new()
             .name("AudioGraph".to_owned())
             .spawn(move || {
-                AudioGraphThread::start(receiver).expect("Could not start AudioGraphThread");
+                AudioGraphThread::start(receiver, sender_).expect("Could not start AudioGraphThread");
             })
             .unwrap();
         Self { sender }

--- a/src/audio/graph.rs
+++ b/src/audio/graph.rs
@@ -1,5 +1,5 @@
-use audio::graph_thread::{AudioGraphThread, AudioGraphThreadMsg};
-use audio::node::{AudioNodeType, AudioNodeMessage};
+use audio::node::{AudioNodeMessage, AudioNodeType};
+use audio::render_thread::{AudioRenderThread, AudioRenderThreadMsg};
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use std::sync::mpsc::{self, Sender};
 use std::thread::Builder;
@@ -7,7 +7,7 @@ use std::thread::Builder;
 static NEXT_NODE_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 
 pub struct AudioGraph {
-    sender: Sender<AudioGraphThreadMsg>,
+    sender: Sender<AudioRenderThreadMsg>,
 }
 
 impl AudioGraph {
@@ -15,9 +15,10 @@ impl AudioGraph {
         let (sender, receiver) = mpsc::channel();
         let sender_ = sender.clone();
         Builder::new()
-            .name("AudioGraph".to_owned())
+            .name("AudioRenderThread".to_owned())
             .spawn(move || {
-                AudioGraphThread::start(receiver, sender_).expect("Could not start AudioGraphThread");
+                AudioRenderThread::start(receiver, sender_)
+                    .expect("Could not start AudioRenderThread");
             })
             .unwrap();
         Self { sender }
@@ -25,19 +26,20 @@ impl AudioGraph {
 
     pub fn create_node(&self, node_type: AudioNodeType) -> usize {
         let node_id = NEXT_NODE_ID.fetch_add(1, Ordering::SeqCst);
-        let _ = self.sender.send(AudioGraphThreadMsg::CreateNode(node_type));
+        let _ = self.sender
+            .send(AudioRenderThreadMsg::CreateNode(node_type));
         node_id
     }
 
     pub fn resume_processing(&self) {
-        let _ = self.sender.send(AudioGraphThreadMsg::ResumeProcessing);
+        let _ = self.sender.send(AudioRenderThreadMsg::ResumeProcessing);
     }
 
     pub fn pause_processing(&self) {
-        let _ = self.sender.send(AudioGraphThreadMsg::PauseProcessing);
+        let _ = self.sender.send(AudioRenderThreadMsg::PauseProcessing);
     }
 
     pub fn message_node(&self, id: usize, msg: AudioNodeMessage) {
-        let _ = self.sender.send(AudioGraphThreadMsg::MessageNode(id, msg));
+        let _ = self.sender.send(AudioRenderThreadMsg::MessageNode(id, msg));
     }
 }

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -2,7 +2,7 @@ pub mod block;
 pub mod destination_node;
 pub mod gain_node;
 pub mod graph;
-pub mod graph_thread;
+pub mod render_thread;
 pub mod node;
 pub mod oscillator_node;
 pub mod sink;

--- a/src/audio/node.rs
+++ b/src/audio/node.rs
@@ -29,7 +29,7 @@ pub trait AudioNodeEngine: Send {
     fn process(
         &self,
         inputs: Chunk,
-        rate: u32,
+        sample_rate: f32,
     ) -> Chunk;
 
     fn message(&mut self, _: AudioNodeMessage) {

--- a/src/audio/oscillator_node.rs
+++ b/src/audio/oscillator_node.rs
@@ -51,7 +51,7 @@ impl AudioNodeEngine for OscillatorNode {
     fn process(
         &self,
         mut inputs: Chunk,
-        rate: u32,
+        sample_rate: f32,
     ) -> Chunk {
         // XXX Implement this properly and according to self.options
         // as defined in https://webaudio.github.io/web-audio-api/#oscillatornode
@@ -68,13 +68,13 @@ impl AudioNodeEngine for OscillatorNode {
             // Convert all our parameters to the target type for calculations
             let vol: f32 = 1.0;
             let freq = self.options.freq as f64;
-            let rate = rate as f64;
+            let sample_rate = sample_rate as f64;
             let two_pi = 2.0 * PI;
 
             // We're carrying a accumulator with up to 2pi around instead of working
             // on the sample offset. High sample offsets cause too much inaccuracy when
             // converted to floating point numbers and then iterated over in 1-steps
-            let step = two_pi * freq / rate;
+            let step = two_pi * freq / sample_rate;
             let mut accumulator = self.accumulator.get();
 
             for sample in data.iter_mut() {

--- a/src/audio/sink.rs
+++ b/src/audio/sink.rs
@@ -1,8 +1,9 @@
-use audio::graph_thread::AudioGraphThread;
-use std::sync::Arc;
+use audio::block::Chunk;
 
 pub trait AudioSink {
-    fn init(&self, Arc<AudioGraphThread>) -> Result<(), ()>;
+    fn init(&self, sample_rate: f32) -> Result<(), ()>;
     fn play(&self);
     fn stop(&self);
+    fn has_enough_data(&self) -> bool;
+    fn push_data(&self, chunk: Chunk) -> Result<(), ()>;
 }

--- a/src/audio/sink.rs
+++ b/src/audio/sink.rs
@@ -1,12 +1,12 @@
 use audio::block::Chunk;
-use audio::graph_thread::AudioGraphThreadMsg;
+use audio::render_thread::AudioRenderThreadMsg;
 use std::sync::mpsc::Sender;
 
 pub trait AudioSink {
     fn init(
         &self,
         sample_rate: f32,
-        graph_thread_channel: Sender<AudioGraphThreadMsg>,
+        render_thread_channel: Sender<AudioRenderThreadMsg>,
     ) -> Result<(), ()>;
     fn play(&self);
     fn stop(&self);

--- a/src/audio/sink.rs
+++ b/src/audio/sink.rs
@@ -1,7 +1,13 @@
 use audio::block::Chunk;
+use audio::graph_thread::AudioGraphThreadMsg;
+use std::sync::mpsc::Sender;
 
 pub trait AudioSink {
-    fn init(&self, sample_rate: f32) -> Result<(), ()>;
+    fn init(
+        &self,
+        sample_rate: f32,
+        graph_thread_channel: Sender<AudioGraphThreadMsg>,
+    ) -> Result<(), ()>;
     fn play(&self);
     fn stop(&self);
     fn has_enough_data(&self) -> bool;

--- a/src/backends/gstreamer/audio_sink.rs
+++ b/src/backends/gstreamer/audio_sink.rs
@@ -1,94 +1,61 @@
-use super::gst_app::{AppSrc, AppSrcCallbacks};
+use super::gst_app::AppSrc;
 use super::gst_audio;
-use audio::block::FRAMES_PER_BLOCK;
-use audio::graph_thread::AudioGraphThread;
+use audio::block::{Chunk, FRAMES_PER_BLOCK};
 use audio::sink::AudioSink;
+use byte_slice_cast::*;
 use gst;
 use gst::prelude::*;
-use std::sync::Arc;
+use std::cell::{Cell, RefCell};
 
 // XXX Define own error type.
 
+const DEFAULT_SAMPLE_RATE: f32 = 44100.;
+
 pub struct GStreamerAudioSink {
     pipeline: gst::Pipeline,
+    appsrc: AppSrc,
+    sample_rate: Cell<f32>,
+    audio_info: RefCell<Option<gst_audio::AudioInfo>>,
+    sample_offset: Cell<u64>,
 }
 
 impl GStreamerAudioSink {
-    pub fn new() -> Self {
-        Self {
-            pipeline: gst::Pipeline::new(None),
-        }
-    }
-}
-
-impl AudioSink for GStreamerAudioSink {
-    fn init(&self, graph: Arc<AudioGraphThread>) -> Result<(), ()> {
+    pub fn new() -> Result<Self, ()> {
         if let Some(category) = gst::DebugCategory::get("openslessink") {
             category.set_threshold(gst::DebugLevel::Trace);
         }
         gst::init().map_err(|_| ())?;
 
-        let src = gst::ElementFactory::make("appsrc", None).ok_or(())?;
-        let src = src.downcast::<AppSrc>().map_err(|_| ())?;
-        let info = gst_audio::AudioInfo::new(gst_audio::AUDIO_FORMAT_F32, 44100, 1)
-            .build()
-            .ok_or(())?;
-        src.set_caps(&info.to_caps().unwrap());
-        src.set_property_format(gst::Format::Time);
-        let mut sample_offset = 0;
-        let n_samples = FRAMES_PER_BLOCK as u64;
-        let buf_size = (n_samples as usize) * (info.bpf() as usize);
+        let appsrc = gst::ElementFactory::make("appsrc", None).ok_or(())?;
+        let appsrc = appsrc.downcast::<AppSrc>().map_err(|_| ())?;
+        Ok(Self {
+            pipeline: gst::Pipeline::new(None),
+            appsrc,
+            sample_rate: Cell::new(DEFAULT_SAMPLE_RATE),
+            audio_info: RefCell::new(None),
+            sample_offset: Cell::new(0),
+        })
+    }
+}
 
-        assert!(info.bpf() == 4);
-        let rate = info.rate();
-
-        let graph_ = graph.clone();
-        let need_data = move |app: &AppSrc, _bytes: u32| {
-            let mut buffer = gst::Buffer::with_size(buf_size).unwrap();
-            {
-                let buffer = buffer.get_mut().unwrap();
-                // Calculate the current timestamp (PTS) and the next one,
-                // and calculate the duration from the difference instead of
-                // simply the number of samples to prevent rounding errors
-                let pts = sample_offset
-                    .mul_div_floor(gst::SECOND_VAL, rate as u64)
-                    .unwrap()
-                    .into();
-                let next_pts: gst::ClockTime = (sample_offset + n_samples)
-                    .mul_div_floor(gst::SECOND_VAL, rate as u64)
-                    .unwrap()
-                    .into();
-                buffer.set_pts(pts);
-                buffer.set_duration(next_pts - pts);
-                
-                let mut chunks = graph_.process(rate);
-                // sometimes nothing reaches the output
-                if chunks.len() == 0 {
-                    chunks.blocks.push(Default::default());
-                    info.format_info().fill_silence(chunks.blocks[0].as_mut_byte_slice());
-                }
-                debug_assert!(chunks.len() == 1);
-                let data = chunks.blocks[0].as_mut_byte_slice();
-
-                // XXXManishearth if we have a safe way to convert
-                // from Box<[f32]> to Box<[u8]> (similarly for Vec)
-                // we can use Buffer::from_slice instead
-                buffer.copy_from_slice(0, data).expect("copying failed");
-
-                sample_offset += n_samples;
-            }
-            let _ = app.push_buffer(buffer);
-        };
-        src.set_callbacks(AppSrcCallbacks::new().need_data(need_data).build());
-
-        let src = src.upcast();
+impl AudioSink for GStreamerAudioSink {
+    fn init(&self, sample_rate: f32) -> Result<(), ()> {
+        self.sample_rate.set(sample_rate);
+        let audio_info =
+            gst_audio::AudioInfo::new(gst_audio::AUDIO_FORMAT_F32, sample_rate as u32, 1)
+                .build()
+                .ok_or(())?;
+        self.appsrc.set_caps(&audio_info.to_caps().unwrap());
+        *self.audio_info.borrow_mut() = Some(audio_info);
+        self.appsrc.set_property_format(gst::Format::Time);
+        let appsrc = self.appsrc.clone().upcast();
         let resample = gst::ElementFactory::make("audioresample", None).ok_or(())?;
         let convert = gst::ElementFactory::make("audioconvert", None).ok_or(())?;
         let sink = gst::ElementFactory::make("autoaudiosink", None).ok_or(())?;
         self.pipeline
-            .add_many(&[&src, &resample, &convert, &sink])
+            .add_many(&[&appsrc, &resample, &convert, &sink])
             .map_err(|_| ())?;
-        gst::Element::link_many(&[&src, &resample, &convert, &sink]).map_err(|_| ())?;
+        gst::Element::link_many(&[&appsrc, &resample, &convert, &sink]).map_err(|_| ())?;
 
         Ok(())
     }
@@ -99,6 +66,61 @@ impl AudioSink for GStreamerAudioSink {
 
     fn stop(&self) {
         let _ = self.pipeline.set_state(gst::State::Paused);
+    }
+
+    fn has_enough_data(&self) -> bool {
+        self.appsrc.get_current_level_bytes() >= self.appsrc.get_max_bytes()
+    }
+
+    fn push_data(&self, mut chunk: Chunk) -> Result<(), ()> {
+        let sample_rate = self.sample_rate.get() as u64;
+        let ref audio_info = self.audio_info.borrow().clone().unwrap();
+        let bpf = audio_info.bpf() as usize;
+        assert!(bpf == 4);
+        let n_samples = FRAMES_PER_BLOCK as u64;
+        let buf_size = (n_samples as usize) * (bpf);
+        let mut buffer = gst::Buffer::with_size(buf_size).unwrap();
+        {
+            let buffer = buffer.get_mut().unwrap();
+            let mut sample_offset = self.sample_offset.get();
+            // Calculate the current timestamp (PTS) and the next one,
+            // and calculate the duration from the difference instead of
+            // simply the number of samples to prevent rounding errors
+            let pts = sample_offset
+                .mul_div_floor(gst::SECOND_VAL, sample_rate)
+                .unwrap()
+                .into();
+            let next_pts: gst::ClockTime = (sample_offset + n_samples)
+                .mul_div_floor(gst::SECOND_VAL, sample_rate)
+                .unwrap()
+                .into();
+            buffer.set_pts(pts);
+            buffer.set_duration(next_pts - pts);
+
+            // sometimes nothing reaches the output
+            if chunk.len() == 0 {
+                chunk.blocks.push(Default::default());
+                audio_info
+                    .format_info()
+                    .fill_silence(chunk.blocks[0].as_mut_byte_slice());
+            }
+            debug_assert!(chunk.len() == 1);
+            let data = &mut chunk.blocks[0].data;
+            let data = data.as_mut_byte_slice().expect("casting failed");
+
+            // XXXManishearth if we have a safe way to convert
+            // from Box<[f32]> to Box<[u8]> (similarly for Vec)
+            // we can use Buffer::from_slice instead
+            buffer.copy_from_slice(0, data).expect("copying failed");
+
+            sample_offset += n_samples;
+            self.sample_offset.set(sample_offset);
+        }
+        self.appsrc
+            .push_buffer(buffer)
+            .into_result()
+            .map(|_| ())
+            .map_err(|_| ())
     }
 }
 

--- a/src/backends/gstreamer/audio_sink.rs
+++ b/src/backends/gstreamer/audio_sink.rs
@@ -74,7 +74,8 @@ impl AudioSink for GStreamerAudioSink {
 
     fn push_data(&self, mut chunk: Chunk) -> Result<(), ()> {
         let sample_rate = self.sample_rate.get() as u64;
-        let ref audio_info = self.audio_info.borrow().clone().unwrap();
+        let audio_info = self.audio_info.borrow();
+        let audio_info = audio_info.as_ref().unwrap();
         let bpf = audio_info.bpf() as usize;
         assert!(bpf == 4);
         let n_samples = FRAMES_PER_BLOCK as u64;


### PR DESCRIPTION
…d tick

This is a different approach for #27.

There is one issue here that can be noticeable running the `play` example. It is supposed to play 2 seconds of two sine waves with different frequencies. With this patch the first sine wave steals most of the time of the second sine wave. I believe it is caused by the difference between the JS clock and the (currently not existent) WebAudio clock (there is a [nice blog post about this](https://www.html5rocks.com/en/tutorials/audio/scheduling/)). If that's the case this should be fixed by using the scheduling feature of AudioScheduledSourceNodes in the play example once #21 is done.