### PR TITLE
Add basic channels abstraction, ChannelMergerNode, and sink support for channels

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -26,3 +26,8 @@ path = "play.rs"
 [[bin]]
 name = "play_noise"
 path = "play_noise.rs"
+
+
+[[bin]]
+name = "channels"
+path = "channels.rs"

--- a/examples/channels.rs
+++ b/examples/channels.rs
@@ -1,0 +1,45 @@
+extern crate servo_media;
+
+use servo_media::audio::channel_node::ChannelNodeOptions;
+use servo_media::audio::gain_node::GainNodeOptions;
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeType};
+use servo_media::audio::oscillator_node::OscillatorNodeMessage;
+use servo_media::audio::param::UserAutomationEvent;
+use servo_media::ServoMedia;
+use std::{thread, time};
+
+fn main() {
+    if let Ok(servo_media) = ServoMedia::get() {
+        let mut graph = servo_media.create_audio_graph();
+        let mut options = Default::default();
+        let osc = graph.create_node(AudioNodeType::OscillatorNode(options));
+        options.freq = 400.;
+        let osc2 = graph.create_node(AudioNodeType::OscillatorNode(options));
+        let mut options = GainNodeOptions::default();
+        options.gain = 0.5;
+        let gain = graph.create_node(AudioNodeType::GainNode(options));
+        let options = ChannelNodeOptions { channels: 2 };
+        let merger = graph.create_node(AudioNodeType::ChannelMergerNode(options));
+
+        let dest = graph.dest_node();
+        graph.connect_ports(osc.output(0), gain.input(0));
+        graph.connect_ports(gain.output(0), merger.input(0));
+        graph.connect_ports(osc2.output(0), merger.input(1));
+        graph.connect_ports(merger.output(0), dest.input(0));
+        graph.message_node(
+            osc,
+            AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::Start(0.)),
+        );
+        graph.message_node(
+            osc2,
+            AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::Start(0.)),
+        );
+        graph.resume();
+
+
+        thread::sleep(time::Duration::from_millis(5000));
+        graph.close();
+    } else {
+        unreachable!();
+    }
+}

--- a/servo-media/src/audio/block.rs
+++ b/servo-media/src/audio/block.rs
@@ -177,8 +177,12 @@ impl<'a> FrameRef<'a> {
     ///
     /// Use this when you plan to do the same operation for each channel.
     /// (Helpers for the other cases will eventually exist)
+    ///
+    /// Block must not be silence
     #[inline]
-    pub fn mutate_frame_with<F>(&mut self, f: F) where F: Fn(&mut f32) {
+    pub fn mutate_with<F>(&mut self, f: F) where F: Fn(&mut f32) {
+        debug_assert!(!self.block.is_silence(), "mutate_frame_with should not be called with a silenced block, \
+                                                 call .explicit_silence() if you wish to use this");
         if self.block.repeat {
             f(&mut self.block.buffer[self.frame.0 as usize])
         } else {

--- a/servo-media/src/audio/block.rs
+++ b/servo-media/src/audio/block.rs
@@ -7,7 +7,7 @@ use std::mem;
 // defined by spec
 // https://webaudio.github.io/web-audio-api/#render-quantum
 pub const FRAMES_PER_BLOCK: Tick = Tick(128);
-const FRAMES_PER_BLOCK_USIZE: usize = FRAMES_PER_BLOCK.0 as usize;
+pub const FRAMES_PER_BLOCK_USIZE: usize = FRAMES_PER_BLOCK.0 as usize;
 
 /// A tick, i.e. the time taken for a single frame
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]

--- a/servo-media/src/audio/channel_node.rs
+++ b/servo-media/src/audio/channel_node.rs
@@ -1,0 +1,42 @@
+use audio::block::FRAMES_PER_BLOCK_USIZE;
+use audio::node::AudioNodeEngine;
+use audio::block::{Block, Chunk};
+use audio::node::BlockInfo;
+
+pub struct ChannelNodeOptions {
+    pub channels: u8,
+}
+
+pub struct ChannelMergerNode {
+    channels: u8
+}
+
+impl ChannelMergerNode {
+    pub fn new(params: ChannelNodeOptions) -> Self {
+        ChannelMergerNode {
+            channels: params.channels
+        }
+    }
+}
+
+impl AudioNodeEngine for ChannelMergerNode {
+    fn process(&mut self, mut inputs: Chunk, _: &BlockInfo) -> Chunk {
+        debug_assert!(inputs.len() == self.channels as usize);
+
+        let mut block = Block::default();
+        block.mix(self.channels);
+        block.explicit_repeat();
+
+        for (i, channel) in block.data_mut().chunks_mut(FRAMES_PER_BLOCK_USIZE).enumerate() {
+            channel.copy_from_slice(inputs.blocks[i].data_mut())
+        }
+
+        inputs.blocks.clear();
+        inputs.blocks.push(block);
+        inputs
+    }
+
+    fn input_count(&self) -> u32 {
+        self.channels as u32
+    }
+}

--- a/servo-media/src/audio/destination_node.rs
+++ b/servo-media/src/audio/destination_node.rs
@@ -22,4 +22,10 @@ impl AudioNodeEngine for DestinationNode {
     fn output_count(&self) -> u32 {
         0
     }
+
+    fn channel_count(&self) -> u8 {
+        // currently hardcoded here and in our invocation of
+        // gst_audio::AudioInfo::new
+        2
+    }
 }

--- a/servo-media/src/audio/graph_impl.rs
+++ b/servo-media/src/audio/graph_impl.rs
@@ -143,11 +143,14 @@ impl GraphImpl {
                     let edge = edge.weight();
                     // XXXManishearth we can have multiple edges
                     // hitting the same input port, we should deal with that
-                    chunk[edge.input_idx] = edge
+                    let mut block = edge
                         .cache
                         .borrow_mut()
                         .take()
                         .expect("Cache should have been filled from traversal");
+                    block.mix(curr.channel_count());
+
+                    chunk[edge.input_idx] = block;
                 }
             }
 

--- a/servo-media/src/audio/mod.rs
+++ b/servo-media/src/audio/mod.rs
@@ -3,6 +3,7 @@ pub mod macros;
 
 pub mod block;
 pub mod buffer_source_node;
+pub mod channel_node;
 pub mod decoder;
 pub mod destination_node;
 pub mod gain_node;

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -54,6 +54,11 @@ pub trait AudioNodeEngine: Send {
         1
     }
 
+    /// Number of input channels for each input port
+    fn channel_count(&self) -> u8 {
+        1
+    }
+
     /// If we're the destination node, extract the contained data
     fn destination_data(&mut self) -> Option<Chunk> {
         None

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -1,3 +1,4 @@
+use audio::channel_node::ChannelNodeOptions;
 use audio::block::{Chunk, Tick};
 use audio::buffer_source_node::{AudioBufferSourceNodeMessage, AudioBufferSourceNodeOptions};
 use audio::gain_node::{GainNodeMessage, GainNodeOptions};
@@ -9,7 +10,7 @@ pub enum AudioNodeType {
     BiquadFilterNode,
     AudioBuffer,
     AudioBufferSourceNode(AudioBufferSourceNodeOptions),
-    ChannelMergerNode,
+    ChannelMergerNode(ChannelNodeOptions),
     ChannelSplitterNode,
     ConstantSourceNode,
     ConvolverNode,

--- a/servo-media/src/audio/oscillator_node.rs
+++ b/servo-media/src/audio/oscillator_node.rs
@@ -9,10 +9,12 @@ pub enum OscillatorNodeMessage {
     Stop(f64),
 }
 
+#[derive(Copy, Clone)]
 pub struct PeriodicWaveOptions {
     // XXX https://webaudio.github.io/web-audio-api/#dictdef-periodicwaveoptions
 }
 
+#[derive(Copy, Clone)]
 pub enum OscillatorType {
     Sine,
     Square,
@@ -21,6 +23,7 @@ pub enum OscillatorType {
     Custom,
 }
 
+#[derive(Copy, Clone)]
 pub struct OscillatorNodeOptions {
     pub oscillator_type: OscillatorType,
     pub freq: f32,

--- a/servo-media/src/audio/oscillator_node.rs
+++ b/servo-media/src/audio/oscillator_node.rs
@@ -94,7 +94,9 @@ impl AudioNodeEngine for OscillatorNode {
         }
 
         {
-            let data = inputs.blocks[0].data_mut();
+
+            inputs.blocks[0].explicit_silence();
+            let mut iter = inputs.blocks[0].iter();
 
             // Convert all our parameters to the target type for calculations
             let vol: f32 = 1.0;
@@ -108,8 +110,8 @@ impl AudioNodeEngine for OscillatorNode {
             //
             // Also, if the frequency changes the phase should not
             let mut step = two_pi * freq / sample_rate;
-            let mut tick = Tick(0);
-            for sample in data.iter_mut() {
+            while let Some(mut frame) = iter.next() {
+                let tick = frame.tick();
                 let (should_play_at, should_break) = self.should_play_at(info.frame + tick);
                 if !should_play_at {
                     if should_break {
@@ -121,13 +123,12 @@ impl AudioNodeEngine for OscillatorNode {
                     step = two_pi * freq / sample_rate;
                 }
                 let value = vol * f32::sin(NumCast::from(self.phase).unwrap());
-                *sample = value;
+                frame.mutate_with(|sample| *sample = value);
 
                 self.phase += step;
                 if self.phase >= two_pi {
                     self.phase -= two_pi;
                 }
-                tick.advance();
             }
         }
         inputs

--- a/servo-media/src/audio/render_thread.rs
+++ b/servo-media/src/audio/render_thread.rs
@@ -1,5 +1,6 @@
 use audio::block::{Chunk, Tick, FRAMES_PER_BLOCK};
 use audio::buffer_source_node::AudioBufferSourceNode;
+use audio::channel_node::ChannelMergerNode;
 use audio::destination_node::DestinationNode;
 use audio::gain_node::GainNode;
 use audio::graph::ProcessingState;
@@ -89,6 +90,7 @@ impl AudioRenderThread {
             AudioNodeType::DestinationNode => Box::new(DestinationNode::new()),
             AudioNodeType::GainNode(options) => Box::new(GainNode::new(options)),
             AudioNodeType::OscillatorNode(options) => Box::new(OscillatorNode::new(options)),
+            AudioNodeType::ChannelMergerNode(options) => Box::new(ChannelMergerNode::new(options)),
             _ => unimplemented!(),
         };
         self.graph.add_node(node)


### PR DESCRIPTION
 - Extends Block to support channels.
 - Makes the DestinationNode have two channels by default. We'll later make this something that the user can set.
 - Adds ChannelMergerNode
 - Implements _very basic_ upmixing from one channel to multiple. Proper upmixing will come later.


Channels are stored as a continuous buffer with each FRAMES_PER_BLOCK chunk being one channel. They can also be grouped together  via `repeat` -- e.g. if an oscillator node produces 2 channels of output, it will actually produce one channel with a `repeat` bit set. Similarly, one-channel blocks will be upmixed to 2-channel `repeat` blocks.

The iterator is a bit awkward due to the lack of associated type constructors (it's a streaming iterator).

part of #18