### PR TITLE
Moar API changes!

### DIFF
--- a/examples/audio_decoder.rs
+++ b/examples/audio_decoder.rs
@@ -2,7 +2,7 @@ extern crate servo_media;
 
 use servo_media::audio::buffer_source_node::AudioBufferSourceNodeMessage;
 use servo_media::audio::decoder::AudioDecoderCallbacks;
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
 use servo_media::ServoMedia;
 use std::env;
 use std::fs::File;
@@ -48,7 +48,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     context.connect_ports(buffer_source.output(0), dest.input(0));
     context.message_node(
         buffer_source,
-        AudioNodeMessage::AudioBufferSourceNode(AudioBufferSourceNodeMessage::Start(0.)),
+        AudioNodeMessage::AudioScheduledSourceNode(AudioScheduledSourceNodeMessage::Start(0.)),
     );
     context.message_node(
         buffer_source,

--- a/examples/channels.rs
+++ b/examples/channels.rs
@@ -2,8 +2,7 @@ extern crate servo_media;
 
 use servo_media::audio::channel_node::ChannelNodeOptions;
 use servo_media::audio::gain_node::GainNodeOptions;
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType};
-use servo_media::audio::oscillator_node::OscillatorNodeMessage;
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
 use servo_media::ServoMedia;
 use std::sync::Arc;
 use std::{thread, time};
@@ -27,11 +26,11 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     context.connect_ports(merger.output(0), dest.input(0));
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::Start(0.)),
+        AudioNodeMessage::AudioScheduledSourceNode(AudioScheduledSourceNodeMessage::Start(0.)),
         );
     context.message_node(
         osc2,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::Start(0.)),
+        AudioNodeMessage::AudioScheduledSourceNode(AudioScheduledSourceNodeMessage::Start(0.)),
         );
     let _ = context.resume();
 

--- a/examples/params.rs
+++ b/examples/params.rs
@@ -1,7 +1,7 @@
 extern crate servo_media;
 
 use servo_media::audio::gain_node::{GainNodeMessage, GainNodeOptions};
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
 use servo_media::audio::oscillator_node::OscillatorNodeMessage;
 use servo_media::audio::param::{RampKind, UserAutomationEvent};
 use servo_media::ServoMedia;
@@ -20,7 +20,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     let _ = context.resume();
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::Start(0.)),
+        AudioNodeMessage::AudioScheduledSourceNode(AudioScheduledSourceNodeMessage::Start(0.)),
     );
     // 0.5s: Set frequency to 110Hz
     context.message_node(

--- a/examples/params_settarget.rs
+++ b/examples/params_settarget.rs
@@ -1,6 +1,6 @@
 extern crate servo_media;
 
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
 use servo_media::audio::oscillator_node::OscillatorNodeMessage;
 use servo_media::audio::param::{RampKind, UserAutomationEvent};
 use servo_media::ServoMedia;
@@ -15,7 +15,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     let _ = context.resume();
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::Start(0.)),
+        AudioNodeMessage::AudioScheduledSourceNode(AudioScheduledSourceNodeMessage::Start(0.)),
     );
     // 0.1s: Set frequency to 110Hz
     context.message_node(

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -1,7 +1,7 @@
 extern crate servo_media;
 
 use servo_media::audio::gain_node::{GainNodeMessage, GainNodeOptions};
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
 use servo_media::audio::oscillator_node::OscillatorNodeMessage;
 use servo_media::audio::param::UserAutomationEvent;
 use servo_media::ServoMedia;
@@ -19,11 +19,11 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     context.connect_ports(gain.output(0), dest.input(0));
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::Start(0.)),
+        AudioNodeMessage::AudioScheduledSourceNode(AudioScheduledSourceNodeMessage::Start(0.)),
     );
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::Stop(3.)),
+        AudioNodeMessage::AudioScheduledSourceNode(AudioScheduledSourceNodeMessage::Stop(3.)),
     );
     assert_eq!(context.current_time(), 0.);
     let _ = context.resume();

--- a/examples/play_noise.rs
+++ b/examples/play_noise.rs
@@ -2,7 +2,7 @@ extern crate rand;
 extern crate servo_media;
 
 use servo_media::audio::buffer_source_node::AudioBufferSourceNodeMessage;
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
 use servo_media::ServoMedia;
 use std::sync::Arc;
 use std::{thread, time};
@@ -18,7 +18,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     }
     context.message_node(
         buffer_source,
-        AudioNodeMessage::AudioBufferSourceNode(AudioBufferSourceNodeMessage::Start(0.)),
+        AudioNodeMessage::AudioScheduledSourceNode(AudioScheduledSourceNodeMessage::Start(0.)),
     );
     context.message_node(
         buffer_source,

--- a/servo-media/src/audio/gain_node.rs
+++ b/servo-media/src/audio/gain_node.rs
@@ -67,5 +67,5 @@ impl AudioNodeEngine for GainNode {
         ChannelCountMode::Max
     }
 
-    make_message_handler!(GainNode);
+    make_message_handler!(GainNode: handle_message);
 }

--- a/servo-media/src/audio/macros.rs
+++ b/servo-media/src/audio/macros.rs
@@ -2,15 +2,22 @@
 macro_rules! make_message_handler(
     (
         $(
-                $node:ident: $handler:ident
-        ),+
+            $node:ident: $handler:ident
+         ),+
     ) => (
         fn message(&mut self, msg: ::audio::node::AudioNodeMessage, sample_rate: f32) {
             match msg {
                 $(::audio::node::AudioNodeMessage::$node(m) => self.$handler(m, sample_rate)),+,
-                ::audio::node::AudioNodeMessage::GetInputCount(tx) => tx.send(self.input_count()).unwrap(),
-                ::audio::node::AudioNodeMessage::GetOutputCount(tx) => tx.send(self.output_count()).unwrap(),
-                ::audio::node::AudioNodeMessage::GetChannelCount(tx) => tx.send(self.channel_count()).unwrap(),
+                ::audio::node::AudioNodeMessage::GetInputCount(tx) =>
+                    tx.send(self.input_count()).unwrap(),
+                ::audio::node::AudioNodeMessage::GetOutputCount(tx) =>
+                    tx.send(self.output_count()).unwrap(),
+                ::audio::node::AudioNodeMessage::GetChannelCount(tx) =>
+                    tx.send(self.channel_count()).unwrap(),
+                ::audio::node::AudioNodeMessage::GetChannelCountMode(tx) =>
+                    tx.send(self.channel_count_mode()).unwrap(),
+                ::audio::node::AudioNodeMessage::GetChannelInterpretation(tx) =>
+                    tx.send(self.channel_interpretation()).unwrap(),
                 _ => (),
             }
         });
@@ -37,5 +44,5 @@ macro_rules! make_render_thread_state_change(
             self.state = ProcessingState::$state;
             self.sink.$sink_method()
         }
+        );
     );
-);

--- a/servo-media/src/audio/macros.rs
+++ b/servo-media/src/audio/macros.rs
@@ -4,6 +4,9 @@ macro_rules! make_message_handler(
         fn message(&mut self, msg: ::audio::node::AudioNodeMessage, sample_rate: f32) {
             match msg {
                 ::audio::node::AudioNodeMessage::$node(m) => self.handle_message(m, sample_rate),
+                ::audio::node::AudioNodeMessage::GetInputCount(tx) => tx.send(self.input_count()).unwrap(),
+                ::audio::node::AudioNodeMessage::GetOutputCount(tx) => tx.send(self.output_count()).unwrap(),
+                ::audio::node::AudioNodeMessage::GetChannelCount(tx) => tx.send(self.channel_count()).unwrap(),
                 _ => (),
             }
         });

--- a/servo-media/src/audio/macros.rs
+++ b/servo-media/src/audio/macros.rs
@@ -1,9 +1,13 @@
 #[macro_export]
 macro_rules! make_message_handler(
-    ($node:ident) => (
+    (
+        $(
+                $node:ident: $handler:ident
+        ),+
+    ) => (
         fn message(&mut self, msg: ::audio::node::AudioNodeMessage, sample_rate: f32) {
             match msg {
-                ::audio::node::AudioNodeMessage::$node(m) => self.handle_message(m, sample_rate),
+                $(::audio::node::AudioNodeMessage::$node(m) => self.$handler(m, sample_rate)),+,
                 ::audio::node::AudioNodeMessage::GetInputCount(tx) => tx.send(self.input_count()).unwrap(),
                 ::audio::node::AudioNodeMessage::GetOutputCount(tx) => tx.send(self.output_count()).unwrap(),
                 ::audio::node::AudioNodeMessage::GetChannelCount(tx) => tx.send(self.channel_count()).unwrap(),

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -90,11 +90,12 @@ pub trait AudioNodeEngine: Send {
 }
 
 pub enum AudioNodeMessage {
+    AudioBufferSourceNode(AudioBufferSourceNodeMessage),
+    AudioScheduledSourceNode(AudioScheduledSourceNodeMessage),
+    GainNode(GainNodeMessage),
+    GetChannelCount(Sender<u8>),
     GetInputCount(Sender<u32>),
     GetOutputCount(Sender<u32>),
-    GetChannelCount(Sender<u8>),
-    AudioBufferSourceNode(AudioBufferSourceNodeMessage),
-    GainNode(GainNodeMessage),
     OscillatorNode(OscillatorNodeMessage),
 }
 
@@ -108,4 +109,11 @@ pub trait AudioScheduledSourceNode {
     /// Schedules a sound to stop playback at an exact time.
     /// Returns true if the scheduling request is processed successfully.
     fn stop(&mut self, tick: Tick) -> bool;
+}
+
+pub enum AudioScheduledSourceNodeMessage {
+    /// Schedules a sound to playback at an exact time.
+    Start(f64),
+    /// Schedules a sound to stop playback at an exact time.
+    Stop(f64),
 }

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -3,6 +3,7 @@ use audio::block::{Chunk, Tick};
 use audio::buffer_source_node::{AudioBufferSourceNodeMessage, AudioBufferSourceNodeOptions};
 use audio::gain_node::{GainNodeMessage, GainNodeOptions};
 use audio::oscillator_node::{OscillatorNodeMessage, OscillatorNodeOptions};
+use std::sync::mpsc::Sender;
 
 /// Type of AudioNodeEngine.
 pub enum AudioNodeType {
@@ -89,6 +90,9 @@ pub trait AudioNodeEngine: Send {
 }
 
 pub enum AudioNodeMessage {
+    GetInputCount(Sender<u32>),
+    GetOutputCount(Sender<u32>),
+    GetChannelCount(Sender<u8>),
     AudioBufferSourceNode(AudioBufferSourceNodeMessage),
     GainNode(GainNodeMessage),
     OscillatorNode(OscillatorNodeMessage),

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -94,6 +94,8 @@ pub enum AudioNodeMessage {
     AudioScheduledSourceNode(AudioScheduledSourceNodeMessage),
     GainNode(GainNodeMessage),
     GetChannelCount(Sender<u8>),
+    GetChannelCountMode(Sender<ChannelCountMode>),
+    GetChannelInterpretation(Sender<ChannelInterpretation>),
     GetInputCount(Sender<u32>),
     GetOutputCount(Sender<u32>),
     OscillatorNode(OscillatorNodeMessage),

--- a/servo-media/src/audio/oscillator_node.rs
+++ b/servo-media/src/audio/oscillator_node.rs
@@ -1,13 +1,11 @@
 use audio::node::ChannelCountMode;
 use audio::block::{Chunk, Tick};
-use audio::node::{AudioNodeEngine, BlockInfo};
+use audio::node::{AudioNodeEngine, AudioScheduledSourceNodeMessage, BlockInfo};
 use audio::param::{Param, UserAutomationEvent};
 use num_traits::cast::NumCast;
 
 pub enum OscillatorNodeMessage {
     SetFrequency(UserAutomationEvent),
-    Start(f64),
-    Stop(f64),
 }
 
 #[derive(Copy, Clone)]
@@ -72,10 +70,15 @@ impl OscillatorNode {
             OscillatorNodeMessage::SetFrequency(event) => {
                 self.frequency.insert_event(event.to_event(sample_rate))
             }
-            OscillatorNodeMessage::Start(when) => {
+        }
+    }
+
+    pub fn handle_source_node_message(&mut self, message: AudioScheduledSourceNodeMessage, sample_rate: f32) {
+        match message {
+            AudioScheduledSourceNodeMessage::Start(when) => {
                 self.start(Tick::from_time(when, sample_rate));
             }
-            OscillatorNodeMessage::Stop(when) => {
+            AudioScheduledSourceNodeMessage::Stop(when) => {
                 self.stop(Tick::from_time(when, sample_rate));
             }
         }
@@ -146,5 +149,6 @@ impl AudioNodeEngine for OscillatorNode {
         ChannelCountMode::Max
     }
 
-    make_message_handler!(OscillatorNode);
+    make_message_handler!(AudioScheduledSourceNode: handle_source_node_message,
+                          OscillatorNode: handle_message);
 }

--- a/servo-media/src/audio/render_thread.rs
+++ b/servo-media/src/audio/render_thread.rs
@@ -64,8 +64,6 @@ impl AudioRenderThread {
 
     make_render_thread_state_change!(suspend, Suspended, stop);
 
-    make_render_thread_state_change!(close, Closed, stop);
-
     fn create_node(&mut self, node_type: AudioNodeType) -> NodeId {
         let node: Box<AudioNodeEngine> = match node_type {
             AudioNodeType::AudioBufferSourceNode(options) => Box::new(AudioBufferSourceNode::new(options)),
@@ -110,7 +108,7 @@ impl AudioRenderThread {
                     let _ = tx.send(context.suspend());
                 }
                 AudioRenderThreadMsg::Close(tx) => {
-                    let _ = tx.send(context.close());
+                    let _ = tx.send(context.suspend());
                     break_loop = true;
                 }
                 AudioRenderThreadMsg::GetCurrentTime(response) => {


### PR DESCRIPTION
Apparently a rendering thread can either be `running` or `suspended`, not `closed`.

The rest are exposed getters and a way to message AudioScheduledSourceNodes directly (and a generic way for a node to implement different message handlers).

r? @Manishearth 
