### PR TITLE
Add support for setting channel information

### DIFF
--- a/examples/channels.rs
+++ b/examples/channels.rs
@@ -11,10 +11,10 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     let context = servo_media.create_audio_context(Default::default());
     let mut options = Default::default();
     let osc = context.create_node(AudioNodeType::OscillatorNode(options));
-    options.freq = 400.;
+    options.freq = 213.;
     let osc2 = context.create_node(AudioNodeType::OscillatorNode(options));
     let mut options = GainNodeOptions::default();
-    options.gain = 0.5;
+    options.gain = 0.7;
     let gain = context.create_node(AudioNodeType::GainNode(options));
     let options = ChannelNodeOptions { channels: 2 };
     let merger = context.create_node(AudioNodeType::ChannelMergerNode(options));
@@ -34,6 +34,8 @@ fn run_example(servo_media: Arc<ServoMedia>) {
         );
     let _ = context.resume();
 
+    thread::sleep(time::Duration::from_millis(5000));
+    context.message_node(dest, AudioNodeMessage::SetChannelCount(1));
     thread::sleep(time::Duration::from_millis(5000));
     let _ = context.close();
 

--- a/examples/channels.rs
+++ b/examples/channels.rs
@@ -34,9 +34,9 @@ fn run_example(servo_media: Arc<ServoMedia>) {
         );
     let _ = context.resume();
 
-    thread::sleep(time::Duration::from_millis(5000));
+    thread::sleep(time::Duration::from_millis(2000));
     context.message_node(dest, AudioNodeMessage::SetChannelCount(1));
-    thread::sleep(time::Duration::from_millis(5000));
+    thread::sleep(time::Duration::from_millis(2000));
     let _ = context.close();
 
 }

--- a/servo-media-derive/src/lib.rs
+++ b/servo-media-derive/src/lib.rs
@@ -61,3 +61,22 @@ fn impl_audio_scheduled_source_node(ast: &syn::DeriveInput) -> quote::Tokens {
         }
     }
 }
+
+#[proc_macro_derive(AudioNodeCommon)]
+pub fn channel_info(input: TokenStream) -> TokenStream {
+    let s = input.to_string();
+    let ast = syn::parse_derive_input(&s).unwrap();
+    let name = &ast.ident;
+    let gen = quote! {
+        impl ::audio::node::AudioNodeCommon for #name {
+            fn channel_info(&self) -> &::audio::node::ChannelInfo {
+                panic!()
+            }
+
+            fn channel_info_mut(&mut self) -> &mut ::audio::node::ChannelInfo {
+                panic!()
+            }
+        }
+    };
+    gen.parse().unwrap()
+}

--- a/servo-media-derive/src/lib.rs
+++ b/servo-media-derive/src/lib.rs
@@ -70,11 +70,11 @@ pub fn channel_info(input: TokenStream) -> TokenStream {
     let gen = quote! {
         impl ::audio::node::AudioNodeCommon for #name {
             fn channel_info(&self) -> &::audio::node::ChannelInfo {
-                panic!()
+                &self.channel_info
             }
 
             fn channel_info_mut(&mut self) -> &mut ::audio::node::ChannelInfo {
-                panic!()
+                &mut self.channel_info
             }
         }
     };

--- a/servo-media/src/audio/buffer_source_node.rs
+++ b/servo-media/src/audio/buffer_source_node.rs
@@ -4,6 +4,7 @@ use audio::node::{AudioNodeEngine, AudioScheduledSourceNodeMessage, BlockInfo};
 use audio::param::Param;
 
 /// Control messages directed to AudioBufferSourceNodes.
+#[derive(Debug, Clone)]
 pub enum AudioBufferSourceNodeMessage {
     /// Set the data block holding the audio sample data to be played.
     // XXX handle channels
@@ -11,6 +12,7 @@ pub enum AudioBufferSourceNodeMessage {
 }
 
 /// This specifies options for constructing an AudioBufferSourceNode.
+#[derive(Debug, Clone)]
 pub struct AudioBufferSourceNodeOptions {
     /// The audio asset to be played.
     pub buffer: Option<AudioBuffer>,
@@ -169,6 +171,7 @@ impl AudioNodeEngine for AudioBufferSourceNode {
                           AudioScheduledSourceNode: handle_source_node_message);
 }
 
+#[derive(Debug, Clone)]
 pub struct AudioBuffer {
     /// Invariant: all buffers must be of the same length
     pub buffers: Vec<Vec<f32>>

--- a/servo-media/src/audio/buffer_source_node.rs
+++ b/servo-media/src/audio/buffer_source_node.rs
@@ -1,5 +1,6 @@
+use audio::node::ChannelInfo;
 use audio::block::{Block, Chunk, Tick, FRAMES_PER_BLOCK};
-use audio::node::{AudioNodeEngine, AudioScheduledSourceNodeMessage, BlockInfo, ChannelCountMode};
+use audio::node::{AudioNodeEngine, AudioScheduledSourceNodeMessage, BlockInfo};
 use audio::param::Param;
 
 /// Control messages directed to AudioBufferSourceNodes.
@@ -45,6 +46,7 @@ impl Default for AudioBufferSourceNodeOptions {
 #[derive(AudioScheduledSourceNode, AudioNodeCommon)]
 #[allow(dead_code)]
 pub struct AudioBufferSourceNode {
+    channel_info: ChannelInfo,
     /// A data block holding the audio sample data to be played.
     buffer: Option<AudioBuffer>,
     /// AudioParam to modulate the speed at which is rendered the audio stream.
@@ -71,6 +73,7 @@ pub struct AudioBufferSourceNode {
 impl AudioBufferSourceNode {
     pub fn new(options: AudioBufferSourceNodeOptions) -> Self {
         Self {
+            channel_info: Default::default(),
             buffer: options.buffer,
             detune: Param::new(options.detune),
             loop_enabled: options.loop_enabled,
@@ -106,10 +109,6 @@ impl AudioBufferSourceNode {
 impl AudioNodeEngine for AudioBufferSourceNode {
     fn input_count(&self) -> u32 {
         0
-    }
-
-    fn channel_count_mode(&self) -> ChannelCountMode {
-        ChannelCountMode::Max
     }
 
     fn process(&mut self, mut inputs: Chunk, info: &BlockInfo) -> Chunk {

--- a/servo-media/src/audio/buffer_source_node.rs
+++ b/servo-media/src/audio/buffer_source_node.rs
@@ -42,7 +42,7 @@ impl Default for AudioBufferSourceNodeOptions {
 /// https://webaudio.github.io/web-audio-api/#AudioBufferSourceNode
 /// XXX Implement looping
 /// XXX Implement playbackRate and related bits
-#[derive(AudioScheduledSourceNode)]
+#[derive(AudioScheduledSourceNode, AudioNodeCommon)]
 #[allow(dead_code)]
 pub struct AudioBufferSourceNode {
     /// A data block holding the audio sample data to be played.

--- a/servo-media/src/audio/channel_node.rs
+++ b/servo-media/src/audio/channel_node.rs
@@ -3,6 +3,7 @@ use audio::node::{AudioNodeEngine, ChannelCountMode, ChannelInfo, ChannelInterpr
 use audio::block::{Block, Chunk};
 use audio::node::BlockInfo;
 
+#[derive(Copy, Clone, Debug)]
 pub struct ChannelNodeOptions {
     pub channels: u8,
 }

--- a/servo-media/src/audio/channel_node.rs
+++ b/servo-media/src/audio/channel_node.rs
@@ -1,6 +1,5 @@
-use audio::node::ChannelCountMode;
 use audio::block::FRAMES_PER_BLOCK_USIZE;
-use audio::node::AudioNodeEngine;
+use audio::node::{AudioNodeEngine, ChannelCountMode, ChannelInfo, ChannelInterpretation};
 use audio::block::{Block, Chunk};
 use audio::node::BlockInfo;
 
@@ -10,12 +9,18 @@ pub struct ChannelNodeOptions {
 
 #[derive(AudioNodeCommon)]
 pub struct ChannelMergerNode {
+    channel_info: ChannelInfo,
     channels: u8
 }
 
 impl ChannelMergerNode {
     pub fn new(params: ChannelNodeOptions) -> Self {
         ChannelMergerNode {
+            channel_info: ChannelInfo {
+                count: 1,
+                mode: ChannelCountMode::Explicit,
+                ..Default::default()
+            },
             channels: params.channels
         }
     }
@@ -43,21 +48,28 @@ impl AudioNodeEngine for ChannelMergerNode {
         self.channels as u32
     }
 
-    fn channel_count_mode(&self) -> ChannelCountMode {
-        ChannelCountMode::Explicit
+    fn set_channel_count_mode(&mut self, _: ChannelCountMode) {
+        panic!("channel merger nodes cannot have their mode changed");
     }
 
+    fn set_channel_count(&mut self, _: u8) {
+        panic!("channel merger nodes cannot have their channel count changed");
+    }
 }
 
 #[derive(AudioNodeCommon)]
 pub struct ChannelSplitterNode {
-    channels: u8
+    channel_info: ChannelInfo,
 }
 
 impl ChannelSplitterNode {
     pub fn new(params: ChannelNodeOptions) -> Self {
         ChannelSplitterNode {
-            channels: params.channels
+            channel_info: ChannelInfo {
+                count: params.channels,
+                mode: ChannelCountMode::Explicit,
+                interpretation: ChannelInterpretation::Discrete,
+            },
         }
     }
 }
@@ -78,11 +90,18 @@ impl AudioNodeEngine for ChannelSplitterNode {
     }
 
     fn output_count(&self) -> u32 {
-        self.channels as u32
+        self.channel_count() as u32
     }
 
-    fn channel_count_mode(&self) -> ChannelCountMode {
-        ChannelCountMode::Explicit
+    fn set_channel_count_mode(&mut self, _: ChannelCountMode) {
+        panic!("channel splitter nodes cannot have their mode changed");
     }
 
+    fn set_channel_interpretation(&mut self, _: ChannelInterpretation) {
+        panic!("channel splitter nodes cannot have their channel interpretation changed");
+    }
+
+    fn set_channel_count(&mut self, _: u8) {
+        panic!("channel splitter nodes cannot have their channel count changed");
+    }
 }

--- a/servo-media/src/audio/channel_node.rs
+++ b/servo-media/src/audio/channel_node.rs
@@ -8,6 +8,7 @@ pub struct ChannelNodeOptions {
     pub channels: u8,
 }
 
+#[derive(AudioNodeCommon)]
 pub struct ChannelMergerNode {
     channels: u8
 }
@@ -48,6 +49,7 @@ impl AudioNodeEngine for ChannelMergerNode {
 
 }
 
+#[derive(AudioNodeCommon)]
 pub struct ChannelSplitterNode {
     channels: u8
 }

--- a/servo-media/src/audio/destination_node.rs
+++ b/servo-media/src/audio/destination_node.rs
@@ -1,37 +1,41 @@
+use audio::node::ChannelInfo;
 use audio::node::ChannelCountMode;
 use audio::node::{AudioNodeEngine, BlockInfo};
 use audio::block::Chunk;
 
 #[derive(AudioNodeCommon)]
-pub struct DestinationNode(Option<Chunk>);
+pub struct DestinationNode {
+    channel_info: ChannelInfo,
+    chunk: Option<Chunk>
+}
 
 impl DestinationNode {
     pub fn new() -> Self {
-        DestinationNode(None)
+        DestinationNode {
+            channel_info: ChannelInfo {
+                    mode: ChannelCountMode::Explicit,
+                    ..Default::default()
+            },
+            chunk: None,
+        }
     }
 }
 
 impl AudioNodeEngine for DestinationNode {
     fn process(&mut self, inputs: Chunk, _: &BlockInfo) -> Chunk {
-        self.0 = Some(inputs);
+        self.chunk = Some(inputs);
         Chunk::default()
     }
 
     fn destination_data(&mut self) -> Option<Chunk> {
-        self.0.take()
+        self.chunk.take()
     } 
 
     fn output_count(&self) -> u32 {
         0
     }
 
-    fn channel_count(&self) -> u8 {
-        // currently hardcoded here and in our invocation of
-        // gst_audio::AudioInfo::new
-        2
-    }
-
-    fn channel_count_mode(&self) -> ChannelCountMode {
-        ChannelCountMode::Explicit
+    fn set_channel_count_mode(&mut self, _: ChannelCountMode) {
+        panic!("destination nodes cannot have their mode changed");
     }
 }

--- a/servo-media/src/audio/destination_node.rs
+++ b/servo-media/src/audio/destination_node.rs
@@ -2,6 +2,7 @@ use audio::node::ChannelCountMode;
 use audio::node::{AudioNodeEngine, BlockInfo};
 use audio::block::Chunk;
 
+#[derive(AudioNodeCommon)]
 pub struct DestinationNode(Option<Chunk>);
 
 impl DestinationNode {

--- a/servo-media/src/audio/gain_node.rs
+++ b/servo-media/src/audio/gain_node.rs
@@ -5,10 +5,12 @@ use audio::node::AudioNodeEngine;
 use audio::node::BlockInfo;
 use audio::param::{Param, UserAutomationEvent};
 
+#[derive(Debug, Clone)]
 pub enum GainNodeMessage {
     SetGain(UserAutomationEvent),
 }
 
+#[derive(Copy, Clone, Debug)]
 pub struct GainNodeOptions {
     pub gain: f32,
 }

--- a/servo-media/src/audio/gain_node.rs
+++ b/servo-media/src/audio/gain_node.rs
@@ -19,6 +19,7 @@ impl Default for GainNodeOptions {
     }
 }
 
+#[derive(AudioNodeCommon)]
 pub struct GainNode {
     gain: Param,
 }

--- a/servo-media/src/audio/gain_node.rs
+++ b/servo-media/src/audio/gain_node.rs
@@ -1,4 +1,4 @@
-use audio::node::ChannelCountMode;
+use audio::node::ChannelInfo;
 use audio::block::Chunk;
 use audio::block::Tick;
 use audio::node::AudioNodeEngine;
@@ -21,12 +21,14 @@ impl Default for GainNodeOptions {
 
 #[derive(AudioNodeCommon)]
 pub struct GainNode {
+    channel_info: ChannelInfo,
     gain: Param,
 }
 
 impl GainNode {
     pub fn new(options: GainNodeOptions) -> Self {
         Self {
+            channel_info: Default::default(),
             gain: Param::new(options.gain),
         }
     }
@@ -62,10 +64,6 @@ impl AudioNodeEngine for GainNode {
             }
         }
         inputs
-    }
-
-    fn channel_count_mode(&self) -> ChannelCountMode {
-        ChannelCountMode::Max
     }
 
     make_message_handler!(GainNode: handle_message);

--- a/servo-media/src/audio/graph.rs
+++ b/servo-media/src/audio/graph.rs
@@ -32,7 +32,7 @@ impl NodeId {
 ///
 /// Kind is a zero sized type and is useful for distinguishing
 /// between input and output ports (which may otherwise share indices)
-#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Debug)]
 pub struct PortIndex<Kind>(pub u32, pub Kind);
 
 impl<Kind> PortId<Kind> {
@@ -42,14 +42,14 @@ impl<Kind> PortId<Kind> {
 }
 
 /// An identifier for a port.
-#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Debug)]
 pub struct PortId<Kind>(NodeId, PortIndex<Kind>);
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 /// Marker type for denoting that the port is an input port
 /// of the node it is connected to
 pub struct InputPort;
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 /// Marker type for denoting that the port is an output port
 /// of the node it is connected to
 pub struct OutputPort;

--- a/servo-media/src/audio/macros.rs
+++ b/servo-media/src/audio/macros.rs
@@ -5,13 +5,14 @@ macro_rules! make_message_handler(
             $node:ident: $handler:ident
          ),+
     ) => (
-        fn message(&mut self, msg: ::audio::node::AudioNodeMessage, sample_rate: f32) {
+        fn message_specific(&mut self, msg: ::audio::node::AudioNodeMessage, sample_rate: f32) {
             match msg {
                 $(::audio::node::AudioNodeMessage::$node(m) => self.$handler(m, sample_rate)),+,
                 _ => (),
             }
-        });
+        }
     );
+);
 
 #[macro_export]
 macro_rules! make_state_change(
@@ -21,8 +22,9 @@ macro_rules! make_state_change(
             let (tx, rx) = mpsc::channel();
             let _ = self.sender.send(AudioRenderThreadMsg::$render_msg(tx));
             rx.recv().unwrap()
-        });
+        }
     );
+);
 
 #[macro_export]
 macro_rules! make_render_thread_state_change(
@@ -34,5 +36,5 @@ macro_rules! make_render_thread_state_change(
             self.state = ProcessingState::$state;
             self.sink.$sink_method()
         }
-        );
     );
+);

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -56,11 +56,45 @@ impl BlockInfo {
     }
 }
 
+
+pub struct ChannelInfo {
+    pub count: u8,
+    pub mode: ChannelCountMode,
+    pub interpretation: ChannelInterpretation,
+}
+
+impl Default for ChannelInfo {
+    fn default() -> Self {
+        ChannelInfo {
+            count: 2,
+            mode: ChannelCountMode::Max,
+            interpretation: ChannelInterpretation::Speakers,
+        }
+    }
+}
+
+
+pub trait AudioNodeCommon {
+    fn channel_info(&self) -> &ChannelInfo;
+
+    fn channel_info_mut(&mut self) -> &mut ChannelInfo;
+}
+
 /// This trait represents the common features of all audio nodes.
-pub trait AudioNodeEngine: Send {
+pub trait AudioNodeEngine: Send + AudioNodeCommon {
     fn process(&mut self, inputs: Chunk, info: &BlockInfo) -> Chunk;
 
-    fn message(&mut self, _: AudioNodeMessage, _sample_rate: f32) {}
+    fn message(&mut self, msg: AudioNodeMessage, sample_rate: f32) {
+        match msg {
+            AudioNodeMessage::SetChannelCount(c) => self.set_channel_count(c),
+            AudioNodeMessage::SetChannelMode(c) => self.set_channel_mode(c),
+            AudioNodeMessage::SetChannelInterpretation(c) => self.set_channel_interpretation(c),
+            _ => self.message_specific(msg, sample_rate),
+        }
+    }
+
+    /// Messages specific to this node
+    fn message_specific(&mut self, _: AudioNodeMessage, _sample_rate: f32) {}
 
     fn input_count(&self) -> u32 {
         1
@@ -71,16 +105,20 @@ pub trait AudioNodeEngine: Send {
 
     /// Number of input channels for each input port
     fn channel_count(&self) -> u8 {
-        1
+        self.channel_info().count
     }
 
     fn channel_count_mode(&self) -> ChannelCountMode {
-        ChannelCountMode::Max
+        self.channel_info().mode
     }
 
     fn channel_interpretation(&self) -> ChannelInterpretation {
-        ChannelInterpretation::Speakers
+        self.channel_info().interpretation
     }
+
+    fn set_channel_interpretation(&mut self, _: ChannelInterpretation) {}
+    fn set_channel_count(&mut self, _: u8) {}
+    fn set_channel_mode(&mut self, _: ChannelCountMode) {}
 
     /// If we're the destination node, extract the contained data
     fn destination_data(&mut self) -> Option<Chunk> {
@@ -93,6 +131,9 @@ pub enum AudioNodeMessage {
     AudioScheduledSourceNode(AudioScheduledSourceNodeMessage),
     GainNode(GainNodeMessage),
     OscillatorNode(OscillatorNodeMessage),
+    SetChannelCount(u8),
+    SetChannelMode(ChannelCountMode),
+    SetChannelInterpretation(ChannelInterpretation),
 }
 
 /// This trait represents the common features of the source nodes such as

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -87,7 +87,7 @@ pub trait AudioNodeEngine: Send + AudioNodeCommon {
     fn message(&mut self, msg: AudioNodeMessage, sample_rate: f32) {
         match msg {
             AudioNodeMessage::SetChannelCount(c) => self.set_channel_count(c),
-            AudioNodeMessage::SetChannelMode(c) => self.set_channel_mode(c),
+            AudioNodeMessage::SetChannelMode(c) => self.set_channel_count_mode(c),
             AudioNodeMessage::SetChannelInterpretation(c) => self.set_channel_interpretation(c),
             _ => self.message_specific(msg, sample_rate),
         }
@@ -116,9 +116,15 @@ pub trait AudioNodeEngine: Send + AudioNodeCommon {
         self.channel_info().interpretation
     }
 
-    fn set_channel_interpretation(&mut self, _: ChannelInterpretation) {}
-    fn set_channel_count(&mut self, _: u8) {}
-    fn set_channel_mode(&mut self, _: ChannelCountMode) {}
+    fn set_channel_interpretation(&mut self, i: ChannelInterpretation) {
+        self.channel_info_mut().interpretation = i
+    }
+    fn set_channel_count(&mut self, c: u8) {
+        self.channel_info_mut().count = c;
+    }
+    fn set_channel_count_mode(&mut self, m: ChannelCountMode) {
+        self.channel_info_mut().mode = m;
+    }
 
     /// If we're the destination node, extract the contained data
     fn destination_data(&mut self) -> Option<Chunk> {

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -5,6 +5,7 @@ use audio::gain_node::{GainNodeMessage, GainNodeOptions};
 use audio::oscillator_node::{OscillatorNodeMessage, OscillatorNodeOptions};
 
 /// Type of AudioNodeEngine.
+#[derive(Debug, Clone)]
 pub enum AudioNodeType {
     AnalyserNode,
     BiquadFilterNode,
@@ -27,7 +28,7 @@ pub enum AudioNodeType {
     WaveShaperNode,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ChannelCountMode {
     Max,
     ClampedMax,
@@ -35,7 +36,7 @@ pub enum ChannelCountMode {
 }
 
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ChannelInterpretation {
     Discrete,
     Speakers
@@ -132,6 +133,7 @@ pub trait AudioNodeEngine: Send + AudioNodeCommon {
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum AudioNodeMessage {
     AudioBufferSourceNode(AudioBufferSourceNodeMessage),
     AudioScheduledSourceNode(AudioScheduledSourceNodeMessage),
@@ -155,6 +157,7 @@ pub trait AudioScheduledSourceNode {
 }
 
 /// Type of message directed to AudioScheduledSourceNodes.
+#[derive(Debug, Clone)]
 pub enum AudioScheduledSourceNodeMessage {
     /// Schedules a sound to playback at an exact time.
     Start(f64),

--- a/servo-media/src/audio/oscillator_node.rs
+++ b/servo-media/src/audio/oscillator_node.rs
@@ -4,16 +4,17 @@ use audio::node::{AudioNodeEngine, AudioScheduledSourceNodeMessage, BlockInfo};
 use audio::param::{Param, UserAutomationEvent};
 use num_traits::cast::NumCast;
 
+#[derive(Copy, Clone, Debug)]
 pub enum OscillatorNodeMessage {
     SetFrequency(UserAutomationEvent),
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct PeriodicWaveOptions {
     // XXX https://webaudio.github.io/web-audio-api/#dictdef-periodicwaveoptions
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum OscillatorType {
     Sine,
     Square,
@@ -22,7 +23,7 @@ pub enum OscillatorType {
     Custom,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct OscillatorNodeOptions {
     pub oscillator_type: OscillatorType,
     pub freq: f32,

--- a/servo-media/src/audio/oscillator_node.rs
+++ b/servo-media/src/audio/oscillator_node.rs
@@ -1,5 +1,6 @@
+use audio::node::ChannelInfo;
 use audio::block::{Chunk, Tick};
-use audio::node::{AudioNodeEngine, AudioScheduledSourceNodeMessage, BlockInfo, ChannelCountMode};
+use audio::node::{AudioNodeEngine, AudioScheduledSourceNodeMessage, BlockInfo};
 use audio::param::{Param, UserAutomationEvent};
 use num_traits::cast::NumCast;
 
@@ -42,6 +43,7 @@ impl Default for OscillatorNodeOptions {
 
 #[derive(AudioScheduledSourceNode, AudioNodeCommon)]
 pub struct OscillatorNode {
+    channel_info: ChannelInfo,
     frequency: Param,
     phase: f64,
     /// Time at which the source should start playing.
@@ -54,6 +56,7 @@ pub struct OscillatorNode {
 impl OscillatorNode {
     pub fn new(options: OscillatorNodeOptions) -> Self {
         Self {
+            channel_info: Default::default(),
             frequency: Param::new(options.freq.into()),
             phase: 0.,
             start_at: None,
@@ -143,10 +146,6 @@ impl AudioNodeEngine for OscillatorNode {
 
     fn input_count(&self) -> u32 {
         0
-    }
-
-    fn channel_count_mode(&self) -> ChannelCountMode {
-        ChannelCountMode::Max
     }
 
     make_message_handler!(AudioScheduledSourceNode: handle_source_node_message,

--- a/servo-media/src/audio/oscillator_node.rs
+++ b/servo-media/src/audio/oscillator_node.rs
@@ -40,7 +40,7 @@ impl Default for OscillatorNodeOptions {
     }
 }
 
-#[derive(AudioScheduledSourceNode)]
+#[derive(AudioScheduledSourceNode, AudioNodeCommon)]
 pub struct OscillatorNode {
     frequency: Param,
     phase: f64,
@@ -49,6 +49,7 @@ pub struct OscillatorNode {
     /// Time at which the source should stop playing.
     stop_at: Option<Tick>,
 }
+
 
 impl OscillatorNode {
     pub fn new(options: OscillatorNodeOptions) -> Self {

--- a/servo-media/src/audio/render_thread.rs
+++ b/servo-media/src/audio/render_thread.rs
@@ -14,6 +14,7 @@ use std::sync::mpsc::{Receiver, Sender};
 #[cfg(feature = "gst")]
 use backends::gstreamer::audio_sink::GStreamerAudioSink;
 
+#[derive(Debug)]
 pub enum AudioRenderThreadMsg {
     CreateNode(AudioNodeType, Sender<NodeId>),
     ConnectPorts(PortId<OutputPort>, PortId<InputPort>),

--- a/servo-media/src/backends/gstreamer/audio_sink.rs
+++ b/servo-media/src/backends/gstreamer/audio_sink.rs
@@ -60,7 +60,7 @@ impl GStreamerAudioSink {
             return Ok(())
         };
         if channels != curr_channels as u8 {
-            self.set_audio_info(self.sample_rate.get(), channels)?
+            self.set_audio_info(self.sample_rate.get(), channels)?;
         }
         Ok(())
     }


### PR DESCRIPTION
I'm trying a trait based trick for keeping message handling common. If you like this
we can use something similar for AudioScheduledSourceNode.

This is also used by the sink, and the example merges channels halfway through by forcing a mix on the sink.


based off #60

r? @ferjm