### PR TITLE
Reduce latency by setting appsrc max-bytes to the block size

### DIFF
--- a/servo-media/src/backends/gstreamer/audio_sink.rs
+++ b/servo-media/src/backends/gstreamer/audio_sink.rs
@@ -76,6 +76,9 @@ impl AudioSink for GStreamerAudioSink {
         self.set_audio_info(sample_rate, 2)?;
         self.appsrc.set_property_format(gst::Format::Time);
 
+        // Allow only a single chunk.
+        self.appsrc.set_max_bytes(1);
+
         let appsrc = self.appsrc.clone();
         Builder::new()
             .name("GstAppSrcCallbacks".to_owned())


### PR DESCRIPTION
With this patch I can notice a much lower latency running the theremin demo.

r? @Manishearth @sdroege