### PR TITLE
Invert edge direction

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+ex = "run -p examples --bin"


### PR DESCRIPTION
(part of #68)

We currently have the edges going in the reverse direction as the audio,
which is confusing. The reason we did this was so that we could use the
DFSPostOrder iterator.

This inverts their direction so that edges now go from source to sink, and
uses a `Reversed` adaptor to fix it.



r? @ferjm