### PR TITLE
Use FnOnce for final decoder callbacks

### DIFF
--- a/servo-media/src/lib.rs
+++ b/servo-media/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(fnbox)]
+
 use std::sync::{self, Once};
 use std::sync::{Arc, Mutex};
 


### PR DESCRIPTION
This avoids having to do a bunch of clones on the caller side. Not strictly necessary, but it's cleaner.