### PR TITLE
Unify setparam methods, various cleanups

### DIFF
--- a/examples/android/lib/src/lib.rs
+++ b/examples/android/lib/src/lib.rs
@@ -2,7 +2,7 @@ extern crate servo_media;
 
 use servo_media::audio::gain_node::GainNodeOptions;
 use servo_media::audio::graph::AudioGraph;
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeInit};
 use servo_media::audio::oscillator_node::OscillatorNodeMessage;
 use servo_media::ServoMedia;
 
@@ -13,14 +13,14 @@ struct AudioStream {
 impl AudioStream {
     pub fn new() -> Self {
         let graph = ServoMedia::get().unwrap().create_audio_graph();
-        graph.create_node(AudioNodeType::OscillatorNode(Default::default()));
+        graph.create_node(AudioNodeInit::OscillatorNode(Default::default()));
         graph.message_node(
             0,
             AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::Start(0.)),
         );
         let mut options = GainNodeOptions::default();
         options.gain = 0.5;
-        graph.create_node(AudioNodeType::GainNode(options));
+        graph.create_node(AudioNodeInit::GainNode(options));
         Self { graph }
     }
 

--- a/examples/audio_decoder.rs
+++ b/examples/audio_decoder.rs
@@ -2,7 +2,7 @@ extern crate servo_media;
 
 use servo_media::audio::buffer_source_node::AudioBufferSourceNodeMessage;
 use servo_media::audio::decoder::AudioDecoderCallbacks;
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeInit, AudioScheduledSourceNodeMessage};
 use servo_media::ServoMedia;
 use std::env;
 use std::fs::File;
@@ -43,7 +43,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     println!("Decoding audio");
     receiver.recv().unwrap();
     println!("Audio decoded");
-    let buffer_source = context.create_node(AudioNodeType::AudioBufferSourceNode(Default::default()));
+    let buffer_source = context.create_node(AudioNodeInit::AudioBufferSourceNode(Default::default()));
     let dest = context.dest_node();
     context.connect_ports(buffer_source.output(0), dest.input(0));
     context.message_node(

--- a/examples/channels.rs
+++ b/examples/channels.rs
@@ -2,7 +2,7 @@ extern crate servo_media;
 
 use servo_media::audio::channel_node::ChannelNodeOptions;
 use servo_media::audio::gain_node::GainNodeOptions;
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeInit, AudioScheduledSourceNodeMessage};
 use servo_media::ServoMedia;
 use std::sync::Arc;
 use std::{thread, time};
@@ -10,14 +10,14 @@ use std::{thread, time};
 fn run_example(servo_media: Arc<ServoMedia>) {
     let context = servo_media.create_audio_context(Default::default());
     let mut options = Default::default();
-    let osc = context.create_node(AudioNodeType::OscillatorNode(options));
+    let osc = context.create_node(AudioNodeInit::OscillatorNode(options));
     options.freq = 213.;
-    let osc2 = context.create_node(AudioNodeType::OscillatorNode(options));
+    let osc2 = context.create_node(AudioNodeInit::OscillatorNode(options));
     let mut options = GainNodeOptions::default();
     options.gain = 0.7;
-    let gain = context.create_node(AudioNodeType::GainNode(options));
+    let gain = context.create_node(AudioNodeInit::GainNode(options));
     let options = ChannelNodeOptions { channels: 2 };
-    let merger = context.create_node(AudioNodeType::ChannelMergerNode(options));
+    let merger = context.create_node(AudioNodeInit::ChannelMergerNode(options));
 
     let dest = context.dest_node();
     context.connect_ports(osc.output(0), gain.input(0));

--- a/examples/channelsum.rs
+++ b/examples/channelsum.rs
@@ -2,7 +2,7 @@ extern crate servo_media;
 
 use servo_media::audio::channel_node::ChannelNodeOptions;
 use servo_media::audio::gain_node::GainNodeOptions;
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeInit, AudioScheduledSourceNodeMessage};
 use servo_media::ServoMedia;
 use std::sync::Arc;
 use std::{thread, time};
@@ -10,17 +10,17 @@ use std::{thread, time};
 fn run_example(servo_media: Arc<ServoMedia>) {
     let context = servo_media.create_audio_context(Default::default());
     let mut options = Default::default();
-    let osc = context.create_node(AudioNodeType::OscillatorNode(options));
+    let osc = context.create_node(AudioNodeInit::OscillatorNode(options));
     options.freq = 213.;
-    let osc2 = context.create_node(AudioNodeType::OscillatorNode(options));
+    let osc2 = context.create_node(AudioNodeInit::OscillatorNode(options));
     options.freq = 100.;
-    let osc3 = context.create_node(AudioNodeType::OscillatorNode(options));
+    let osc3 = context.create_node(AudioNodeInit::OscillatorNode(options));
     let mut options = GainNodeOptions::default();
     options.gain = 0.7;
-    let gain = context.create_node(AudioNodeType::GainNode(options));
+    let gain = context.create_node(AudioNodeInit::GainNode(options));
 
     let options = ChannelNodeOptions { channels: 2 };
-    let merger = context.create_node(AudioNodeType::ChannelMergerNode(options));
+    let merger = context.create_node(AudioNodeInit::ChannelMergerNode(options));
 
     let dest = context.dest_node();
     context.connect_ports(osc.output(0), merger.input(0));

--- a/examples/params.rs
+++ b/examples/params.rs
@@ -1,9 +1,8 @@
 extern crate servo_media;
 
-use servo_media::audio::gain_node::{GainNodeMessage, GainNodeOptions};
+use servo_media::audio::gain_node::GainNodeOptions;
 use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
-use servo_media::audio::oscillator_node::OscillatorNodeMessage;
-use servo_media::audio::param::{RampKind, UserAutomationEvent};
+use servo_media::audio::param::{ParamType, RampKind, UserAutomationEvent};
 use servo_media::ServoMedia;
 use std::sync::Arc;
 use std::{thread, time};
@@ -25,59 +24,67 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     // 0.5s: Set frequency to 110Hz
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::SetValueAtTime(110., 0.5),
-        )),
+        ),
     );
     // 1s: Set frequency to 220Hz
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::SetValueAtTime(220., 1.),
-        )),
+        ),
     );
     // 0.75s: Set gain to 0.25
     context.message_node(
         gain,
-        AudioNodeMessage::GainNode(GainNodeMessage::SetGain(
+        AudioNodeMessage::SetParam(
+            ParamType::Gain,
             UserAutomationEvent::SetValueAtTime(0.25, 0.75),
-        )),
+        ),
     );
     // 0.75s - 1.5s: Exponentially ramp gain to 1
     context.message_node(
         gain,
-        AudioNodeMessage::GainNode(GainNodeMessage::SetGain(
+        AudioNodeMessage::SetParam(
+            ParamType::Gain,
             UserAutomationEvent::RampToValueAtTime(RampKind::Exponential, 1., 1.5),
-        )),
+        ),
     );
     // 0.75s - 1.75s: Linearly ramp frequency to 880Hz
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::RampToValueAtTime(RampKind::Linear, 880., 1.75),
-        )),
+        ),
     );
     // 1.75s - 2.5s: Exponentially ramp frequency to 110Hz
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::RampToValueAtTime(RampKind::Exponential, 110., 2.5),
-        )),
+        ),
     );
 
     // 2.75s: Exponentially approach 110Hz
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::SetTargetAtTime(1100., 2.75, 1.1),
-        )),
+        ),
     );
     // 3.3s: But actually stop at 3.3Hz and hold
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::CancelAndHoldAtTime(3.3),
-        )),
+        ),
     );
     thread::sleep(time::Duration::from_millis(5000));
 }

--- a/examples/params.rs
+++ b/examples/params.rs
@@ -1,7 +1,7 @@
 extern crate servo_media;
 
 use servo_media::audio::gain_node::GainNodeOptions;
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeInit, AudioScheduledSourceNodeMessage};
 use servo_media::audio::param::{ParamType, RampKind, UserAutomationEvent};
 use servo_media::ServoMedia;
 use std::sync::Arc;
@@ -10,10 +10,10 @@ use std::{thread, time};
 fn run_example(servo_media: Arc<ServoMedia>) {
     let context = servo_media.create_audio_context(Default::default());
     let dest = context.dest_node();
-    let osc = context.create_node(AudioNodeType::OscillatorNode(Default::default()));
+    let osc = context.create_node(AudioNodeInit::OscillatorNode(Default::default()));
     let mut options = GainNodeOptions::default();
     options.gain = 0.5;
-    let gain = context.create_node(AudioNodeType::GainNode(options));
+    let gain = context.create_node(AudioNodeInit::GainNode(options));
     context.connect_ports(osc.output(0), gain.input(0));
     context.connect_ports(gain.output(0), dest.input(0));
     let _ = context.resume();

--- a/examples/params_settarget.rs
+++ b/examples/params_settarget.rs
@@ -1,8 +1,7 @@
 extern crate servo_media;
 
 use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
-use servo_media::audio::oscillator_node::OscillatorNodeMessage;
-use servo_media::audio::param::{RampKind, UserAutomationEvent};
+use servo_media::audio::param::{ParamType, RampKind, UserAutomationEvent};
 use servo_media::ServoMedia;
 use std::sync::Arc;
 use std::{thread, time};
@@ -20,32 +19,36 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     // 0.1s: Set frequency to 110Hz
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::SetValueAtTime(110., 0.1),
-        )),
+        ),
     );
     // 0.3s: Start increasing frequency to 440Hz exponentially with a time constant of 1
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::SetTargetAtTime(440., 0.3, 1.),
-        )),
+        ),
     );
     // 1.5s: Start increasing frequency to 1760Hz exponentially
     // this event effectively doesn't happen, but instead sets a starting point
     // for the next ramp event
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::SetTargetAtTime(1760., 1.5, 0.1),
-        )),
+        ),
     );
     // 1.5s - 3s Linearly ramp down from the previous event (1.5s) to 110Hz
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::RampToValueAtTime(RampKind::Linear, 110., 3.0),
-        )),
+        ),
     );
     thread::sleep(time::Duration::from_millis(5000));
 }

--- a/examples/params_settarget.rs
+++ b/examples/params_settarget.rs
@@ -1,6 +1,6 @@
 extern crate servo_media;
 
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeInit, AudioScheduledSourceNodeMessage};
 use servo_media::audio::param::{ParamType, RampKind, UserAutomationEvent};
 use servo_media::ServoMedia;
 use std::sync::Arc;
@@ -9,7 +9,7 @@ use std::{thread, time};
 fn run_example(servo_media: Arc<ServoMedia>) {
     let context = servo_media.create_audio_context(Default::default());
     let dest = context.dest_node();
-    let osc = context.create_node(AudioNodeType::OscillatorNode(Default::default()));
+    let osc = context.create_node(AudioNodeInit::OscillatorNode(Default::default()));
     context.connect_ports(osc.output(0), dest.input(0));
     let _ = context.resume();
     context.message_node(

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -1,9 +1,8 @@
 extern crate servo_media;
 
-use servo_media::audio::gain_node::{GainNodeMessage, GainNodeOptions};
+use servo_media::audio::gain_node::{GainNodeOptions};
 use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
-use servo_media::audio::oscillator_node::OscillatorNodeMessage;
-use servo_media::audio::param::UserAutomationEvent;
+use servo_media::audio::param::{ParamType, UserAutomationEvent};
 use servo_media::ServoMedia;
 use std::sync::Arc;
 use std::{thread, time};
@@ -30,23 +29,26 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     // 0.5s: Set frequency to 110Hz
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::SetValueAtTime(110., 0.5),
-        )),
+        ),
     );
     // 1s: Set frequency to 220Hz
     context.message_node(
         osc,
-        AudioNodeMessage::OscillatorNode(OscillatorNodeMessage::SetFrequency(
+        AudioNodeMessage::SetParam(
+            ParamType::Frequency,
             UserAutomationEvent::SetValueAtTime(220., 1.),
-        )),
+        ),
     );
     // 0.75s: Set gain to 0.25
     context.message_node(
         gain,
-        AudioNodeMessage::GainNode(GainNodeMessage::SetGain(
+        AudioNodeMessage::SetParam(
+            ParamType::Gain,
             UserAutomationEvent::SetValueAtTime(0.25, 0.75),
-        )),
+        ),
     );
     thread::sleep(time::Duration::from_millis(1200));
     // 1.2s: Suspend processing

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -1,7 +1,7 @@
 extern crate servo_media;
 
 use servo_media::audio::gain_node::{GainNodeOptions};
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeInit, AudioScheduledSourceNodeMessage};
 use servo_media::audio::param::{ParamType, UserAutomationEvent};
 use servo_media::ServoMedia;
 use std::sync::Arc;
@@ -9,10 +9,10 @@ use std::{thread, time};
 
 fn run_example(servo_media: Arc<ServoMedia>) {
     let context = servo_media.create_audio_context(Default::default());
-    let osc = context.create_node(AudioNodeType::OscillatorNode(Default::default()));
+    let osc = context.create_node(AudioNodeInit::OscillatorNode(Default::default()));
     let mut options = GainNodeOptions::default();
     options.gain = 0.5;
-    let gain = context.create_node(AudioNodeType::GainNode(options));
+    let gain = context.create_node(AudioNodeInit::GainNode(options));
     let dest = context.dest_node();
     context.connect_ports(osc.output(0), gain.input(0));
     context.connect_ports(gain.output(0), dest.input(0));

--- a/examples/play_noise.rs
+++ b/examples/play_noise.rs
@@ -2,14 +2,14 @@ extern crate rand;
 extern crate servo_media;
 
 use servo_media::audio::buffer_source_node::AudioBufferSourceNodeMessage;
-use servo_media::audio::node::{AudioNodeMessage, AudioNodeType, AudioScheduledSourceNodeMessage};
+use servo_media::audio::node::{AudioNodeMessage, AudioNodeInit, AudioScheduledSourceNodeMessage};
 use servo_media::ServoMedia;
 use std::sync::Arc;
 use std::{thread, time};
 
 fn run_example(servo_media: Arc<ServoMedia>) {
     let context = servo_media.create_audio_context(Default::default());
-    let buffer_source = context.create_node(AudioNodeType::AudioBufferSourceNode(Default::default()));
+    let buffer_source = context.create_node(AudioNodeInit::AudioBufferSourceNode(Default::default()));
     let dest = context.dest_node();
     context.connect_ports(buffer_source.output(0), dest.input(0));
     let mut buffers = vec![Vec::with_capacity(4096), Vec::with_capacity(4096)];

--- a/servo-media/src/audio/buffer_source_node.rs
+++ b/servo-media/src/audio/buffer_source_node.rs
@@ -1,15 +1,13 @@
 use audio::node::{AudioNodeType, ChannelInfo};
 use audio::block::{Block, Chunk, Tick, FRAMES_PER_BLOCK};
 use audio::node::{AudioNodeEngine, AudioScheduledSourceNodeMessage, BlockInfo};
-use audio::param::{Param, UserAutomationEvent};
+use audio::param::{Param, ParamType};
 
 /// Control messages directed to AudioBufferSourceNodes.
 #[derive(Debug, Clone)]
 pub enum AudioBufferSourceNodeMessage {
     /// Set the data block holding the audio sample data to be played.
     SetBuffer(Option<AudioBuffer>),
-    SetPlaybackRate(UserAutomationEvent),
-    SetDetune(UserAutomationEvent),
 }
 
 /// This specifies options for constructing an AudioBufferSourceNode.
@@ -89,17 +87,11 @@ impl AudioBufferSourceNode {
         }
     }
 
-    pub fn handle_message(&mut self, message: AudioBufferSourceNodeMessage, sample_rate: f32) {
+    pub fn handle_message(&mut self, message: AudioBufferSourceNodeMessage, _: f32) {
         match message {
             AudioBufferSourceNodeMessage::SetBuffer(buffer) => {
                 self.buffer = buffer;
             },
-            AudioBufferSourceNodeMessage::SetPlaybackRate(event) => {
-                self.playback_rate.insert_event(event.to_event(sample_rate));
-            },
-            AudioBufferSourceNodeMessage::SetDetune(event) => {
-                self.detune.insert_event(event.to_event(sample_rate));
-            }
         }
     }
 
@@ -174,6 +166,14 @@ impl AudioNodeEngine for AudioBufferSourceNode {
 
         self.playback_offset = next_offset;
         inputs
+    }
+
+    fn get_param(&mut self, id: ParamType) -> &mut Param {
+        match id {
+            ParamType::PlaybackRate => &mut self.playback_rate,
+            ParamType::Detune => &mut self.detune,
+            _ => panic!("Unknown param {:?} for AudioBufferSourceNode", id)
+        }
     }
 
     make_message_handler!(AudioBufferSourceNode: handle_message,

--- a/servo-media/src/audio/buffer_source_node.rs
+++ b/servo-media/src/audio/buffer_source_node.rs
@@ -48,7 +48,7 @@ impl Default for AudioBufferSourceNodeOptions {
 /// XXX Implement playbackRate and related bits
 #[derive(AudioScheduledSourceNode, AudioNodeCommon)]
 #[allow(dead_code)]
-pub struct AudioBufferSourceNode {
+pub(crate) struct AudioBufferSourceNode {
     channel_info: ChannelInfo,
     /// A data block holding the audio sample data to be played.
     buffer: Option<AudioBuffer>,

--- a/servo-media/src/audio/buffer_source_node.rs
+++ b/servo-media/src/audio/buffer_source_node.rs
@@ -1,4 +1,4 @@
-use audio::node::ChannelInfo;
+use audio::node::{AudioNodeType, ChannelInfo};
 use audio::block::{Block, Chunk, Tick, FRAMES_PER_BLOCK};
 use audio::node::{AudioNodeEngine, AudioScheduledSourceNodeMessage, BlockInfo};
 use audio::param::{Param, UserAutomationEvent};
@@ -116,7 +116,7 @@ impl AudioBufferSourceNode {
 }
 
 impl AudioNodeEngine for AudioBufferSourceNode {
-    fn node_type(&self) -> &'static str { "AudioBufferSourceNode" }
+    fn node_type(&self) -> AudioNodeType { AudioNodeType::AudioBufferSourceNode }
 
     fn input_count(&self) -> u32 {
         0

--- a/servo-media/src/audio/buffer_source_node.rs
+++ b/servo-media/src/audio/buffer_source_node.rs
@@ -116,6 +116,8 @@ impl AudioBufferSourceNode {
 }
 
 impl AudioNodeEngine for AudioBufferSourceNode {
+    fn node_type(&self) -> &'static str { "AudioBufferSourceNode" }
+
     fn input_count(&self) -> u32 {
         0
     }

--- a/servo-media/src/audio/channel_node.rs
+++ b/servo-media/src/audio/channel_node.rs
@@ -1,4 +1,5 @@
 use audio::block::FRAMES_PER_BLOCK_USIZE;
+use audio::node::AudioNodeType;
 use audio::node::{AudioNodeEngine, ChannelCountMode, ChannelInfo, ChannelInterpretation};
 use audio::block::{Block, Chunk};
 use audio::node::BlockInfo;
@@ -28,7 +29,7 @@ impl ChannelMergerNode {
 }
 
 impl AudioNodeEngine for ChannelMergerNode {
-    fn node_type(&self) -> &'static str { "ChannelMergerNode" }
+    fn node_type(&self) -> AudioNodeType { AudioNodeType::ChannelMergerNode }
 
     fn process(&mut self, mut inputs: Chunk, _: &BlockInfo) -> Chunk {
         debug_assert!(inputs.len() == self.channels as usize);
@@ -78,7 +79,7 @@ impl ChannelSplitterNode {
 }
 
 impl AudioNodeEngine for ChannelSplitterNode {
-    fn node_type(&self) -> &'static str { "ChannelSplitterNode" }
+    fn node_type(&self) -> AudioNodeType { AudioNodeType::ChannelSplitterNode }
 
     fn process(&mut self, mut inputs: Chunk, _: &BlockInfo) -> Chunk {
         debug_assert!(inputs.len() == 1);

--- a/servo-media/src/audio/channel_node.rs
+++ b/servo-media/src/audio/channel_node.rs
@@ -28,6 +28,8 @@ impl ChannelMergerNode {
 }
 
 impl AudioNodeEngine for ChannelMergerNode {
+    fn node_type(&self) -> &'static str { "ChannelMergerNode" }
+
     fn process(&mut self, mut inputs: Chunk, _: &BlockInfo) -> Chunk {
         debug_assert!(inputs.len() == self.channels as usize);
 
@@ -76,6 +78,8 @@ impl ChannelSplitterNode {
 }
 
 impl AudioNodeEngine for ChannelSplitterNode {
+    fn node_type(&self) -> &'static str { "ChannelSplitterNode" }
+
     fn process(&mut self, mut inputs: Chunk, _: &BlockInfo) -> Chunk {
         debug_assert!(inputs.len() == 1);
 

--- a/servo-media/src/audio/channel_node.rs
+++ b/servo-media/src/audio/channel_node.rs
@@ -9,7 +9,7 @@ pub struct ChannelNodeOptions {
 }
 
 #[derive(AudioNodeCommon)]
-pub struct ChannelMergerNode {
+pub(crate) struct ChannelMergerNode {
     channel_info: ChannelInfo,
     channels: u8
 }
@@ -61,7 +61,7 @@ impl AudioNodeEngine for ChannelMergerNode {
 }
 
 #[derive(AudioNodeCommon)]
-pub struct ChannelSplitterNode {
+pub(crate) struct ChannelSplitterNode {
     channel_info: ChannelInfo,
 }
 

--- a/servo-media/src/audio/context.rs
+++ b/servo-media/src/audio/context.rs
@@ -1,6 +1,6 @@
 use audio::decoder::{AudioDecoder, AudioDecoderCallbacks, AudioDecoderOptions};
 use audio::graph::{AudioGraph, InputPort, NodeId, OutputPort, PortId};
-use audio::node::{AudioNodeMessage, AudioNodeType};
+use audio::node::{AudioNodeMessage, AudioNodeInit};
 use audio::render_thread::AudioRenderThread;
 use audio::render_thread::AudioRenderThreadMsg;
 use std::cell::Cell;
@@ -154,7 +154,7 @@ impl AudioContext {
         rx.recv().unwrap()
     }
 
-    pub fn create_node(&self, node_type: AudioNodeType) -> NodeId {
+    pub fn create_node(&self, node_type: AudioNodeInit) -> NodeId {
         let (tx, rx) = mpsc::channel();
         let _ = self.sender
             .send(AudioRenderThreadMsg::CreateNode(node_type, tx));

--- a/servo-media/src/audio/destination_node.rs
+++ b/servo-media/src/audio/destination_node.rs
@@ -4,7 +4,7 @@ use audio::node::{AudioNodeEngine, BlockInfo};
 use audio::block::Chunk;
 
 #[derive(AudioNodeCommon)]
-pub struct DestinationNode {
+pub(crate) struct DestinationNode {
     channel_info: ChannelInfo,
     chunk: Option<Chunk>
 }

--- a/servo-media/src/audio/destination_node.rs
+++ b/servo-media/src/audio/destination_node.rs
@@ -22,6 +22,8 @@ impl DestinationNode {
 }
 
 impl AudioNodeEngine for DestinationNode {
+    fn node_type(&self) -> &'static str { "DestinationNode" }
+
     fn process(&mut self, inputs: Chunk, _: &BlockInfo) -> Chunk {
         self.chunk = Some(inputs);
         Chunk::default()

--- a/servo-media/src/audio/destination_node.rs
+++ b/servo-media/src/audio/destination_node.rs
@@ -1,5 +1,4 @@
-use audio::node::ChannelInfo;
-use audio::node::ChannelCountMode;
+use audio::node::{AudioNodeType, ChannelCountMode, ChannelInfo};
 use audio::node::{AudioNodeEngine, BlockInfo};
 use audio::block::Chunk;
 
@@ -22,7 +21,7 @@ impl DestinationNode {
 }
 
 impl AudioNodeEngine for DestinationNode {
-    fn node_type(&self) -> &'static str { "DestinationNode" }
+    fn node_type(&self) -> AudioNodeType { AudioNodeType::DestinationNode }
 
     fn process(&mut self, inputs: Chunk, _: &BlockInfo) -> Chunk {
         self.chunk = Some(inputs);

--- a/servo-media/src/audio/gain_node.rs
+++ b/servo-media/src/audio/gain_node.rs
@@ -1,4 +1,4 @@
-use audio::node::ChannelInfo;
+use audio::node::{AudioNodeType, ChannelInfo};
 use audio::block::Chunk;
 use audio::block::Tick;
 use audio::node::AudioNodeEngine;
@@ -37,7 +37,7 @@ impl GainNode {
 
 impl AudioNodeEngine for GainNode {
 
-    fn node_type(&self) -> &'static str { "GainNode" }
+    fn node_type(&self) -> AudioNodeType { AudioNodeType::GainNode }
 
     fn process(&mut self, mut inputs: Chunk, info: &BlockInfo) -> Chunk {
         debug_assert!(inputs.len() == 1);

--- a/servo-media/src/audio/gain_node.rs
+++ b/servo-media/src/audio/gain_node.rs
@@ -17,7 +17,7 @@ impl Default for GainNodeOptions {
 }
 
 #[derive(AudioNodeCommon)]
-pub struct GainNode {
+pub(crate) struct GainNode {
     channel_info: ChannelInfo,
     gain: Param,
 }

--- a/servo-media/src/audio/gain_node.rs
+++ b/servo-media/src/audio/gain_node.rs
@@ -3,12 +3,7 @@ use audio::block::Chunk;
 use audio::block::Tick;
 use audio::node::AudioNodeEngine;
 use audio::node::BlockInfo;
-use audio::param::{Param, UserAutomationEvent};
-
-#[derive(Debug, Clone)]
-pub enum GainNodeMessage {
-    SetGain(UserAutomationEvent),
-}
+use audio::param::{Param, ParamType};
 
 #[derive(Copy, Clone, Debug)]
 pub struct GainNodeOptions {
@@ -38,12 +33,6 @@ impl GainNode {
     pub fn update_parameters(&mut self, info: &BlockInfo, tick: Tick) -> bool {
         self.gain.update(info, tick)
     }
-
-    pub fn handle_message(&mut self, message: GainNodeMessage, sample_rate: f32) {
-        match message {
-            GainNodeMessage::SetGain(event) => self.gain.insert_event(event.to_event(sample_rate)),
-        }
-    }
 }
 
 impl AudioNodeEngine for GainNode {
@@ -71,5 +60,11 @@ impl AudioNodeEngine for GainNode {
         inputs
     }
 
-    make_message_handler!(GainNode: handle_message);
+
+    fn get_param(&mut self, id: ParamType) -> &mut Param {
+        match id {
+            ParamType::Gain => &mut self.gain,
+            _ => panic!("Unknown param {:?} for GainNode", id)
+        }
+    }
 }

--- a/servo-media/src/audio/gain_node.rs
+++ b/servo-media/src/audio/gain_node.rs
@@ -47,6 +47,9 @@ impl GainNode {
 }
 
 impl AudioNodeEngine for GainNode {
+
+    fn node_type(&self) -> &'static str { "GainNode" }
+
     fn process(&mut self, mut inputs: Chunk, info: &BlockInfo) -> Chunk {
         debug_assert!(inputs.len() == 1);
 

--- a/servo-media/src/audio/graph.rs
+++ b/servo-media/src/audio/graph.rs
@@ -7,7 +7,7 @@ use petgraph::graph::DefaultIx;
 use petgraph::stable_graph::NodeIndex;
 use petgraph::stable_graph::StableGraph;
 use petgraph::visit::{DfsPostOrder, EdgeRef, Reversed};
-use std::cell::{Ref, RefCell, RefMut};
+use std::cell::{RefCell, RefMut};
 use std::cmp;
 
 #[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Debug)]
@@ -60,7 +60,7 @@ pub struct AudioGraph {
     dest_id: NodeId,
 }
 
-pub struct Node {
+pub(crate) struct Node {
     node: RefCell<Box<AudioNodeEngine>>,
 }
 
@@ -71,7 +71,7 @@ pub struct Node {
 /// WebAudio allows for multiple connections to/from the same port
 /// however it does not allow for duplicate connections between pairs
 /// of ports
-pub struct Edge {
+pub(crate) struct Edge {
     connections: SmallVec<[Connection; 1]>
 }
 
@@ -118,7 +118,7 @@ impl AudioGraph {
     }
 
     /// Create a node, obtain its id
-    pub fn add_node(&mut self, node: Box<AudioNodeEngine>) -> NodeId {
+    pub(crate) fn add_node(&mut self, node: Box<AudioNodeEngine>) -> NodeId {
         NodeId(self.graph.add_node(Node::new(node)))
     }
 
@@ -361,13 +361,8 @@ impl AudioGraph {
 
 
     /// Obtain a mutable reference to a node
-    pub fn node_mut(&self, ix: NodeId) -> RefMut<Box<AudioNodeEngine>> {
+    pub(crate) fn node_mut(&self, ix: NodeId) -> RefMut<Box<AudioNodeEngine>> {
         self.graph[ix.0].node.borrow_mut()
-    }
-
-    /// Obtain an immutable reference to a node
-    pub fn node(&self, ix: NodeId) -> Ref<Box<AudioNodeEngine>> {
-        self.graph[ix.0].node.borrow()
     }
 }
 

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -5,7 +5,7 @@ use audio::buffer_source_node::{AudioBufferSourceNodeMessage, AudioBufferSourceN
 use audio::gain_node::GainNodeOptions;
 use audio::oscillator_node::OscillatorNodeOptions;
 
-/// Type of AudioNodeEngine.
+/// Information required to construct an audio node
 #[derive(Debug, Clone)]
 pub enum AudioNodeInit {
     AnalyserNode,
@@ -28,6 +28,31 @@ pub enum AudioNodeInit {
     StereoPannerNode,
     WaveShaperNode,
 }
+
+/// Type of AudioNodeEngine.
+#[derive(Debug, Clone, Copy)]
+pub enum AudioNodeType {
+    AnalyserNode,
+    BiquadFilterNode,
+    AudioBuffer,
+    AudioBufferSourceNode,
+    ChannelMergerNode,
+    ChannelSplitterNode,
+    ConstantSourceNode,
+    ConvolverNode,
+    DelayNode,
+    DestinationNode,
+    DynamicsCompressionNode,
+    GainNode,
+    IIRFilterNode,
+    OscillatorNode,
+    PannerNode,
+    PeriodicWave,
+    ScriptProcessorNode,
+    StereoPannerNode,
+    WaveShaperNode,
+}
+
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ChannelCountMode {
@@ -84,7 +109,7 @@ pub(crate) trait AudioNodeCommon {
 
 /// This trait represents the common features of all audio nodes.
 pub(crate) trait AudioNodeEngine: Send + AudioNodeCommon {
-    fn node_type(&self) -> &'static str;
+    fn node_type(&self) -> AudioNodeType;
 
     fn process(&mut self, inputs: Chunk, info: &BlockInfo) -> Chunk;
 
@@ -139,7 +164,7 @@ pub(crate) trait AudioNodeEngine: Send + AudioNodeCommon {
     }
 
     fn get_param(&mut self, _: ParamType) -> &mut Param {
-        panic!("No params on node {}", self.node_type())
+        panic!("No params on node {:?}", self.node_type())
     }
 }
 

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -7,7 +7,7 @@ use audio::oscillator_node::OscillatorNodeOptions;
 
 /// Type of AudioNodeEngine.
 #[derive(Debug, Clone)]
-pub enum AudioNodeType {
+pub enum AudioNodeInit {
     AnalyserNode,
     BiquadFilterNode,
     AudioBuffer,

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -1,9 +1,9 @@
-use audio::param::{Param, ParamType};
+use audio::param::{Param, ParamType, UserAutomationEvent};
 use audio::channel_node::ChannelNodeOptions;
 use audio::block::{Chunk, Tick};
 use audio::buffer_source_node::{AudioBufferSourceNodeMessage, AudioBufferSourceNodeOptions};
-use audio::gain_node::{GainNodeMessage, GainNodeOptions};
-use audio::oscillator_node::{OscillatorNodeMessage, OscillatorNodeOptions};
+use audio::gain_node::GainNodeOptions;
+use audio::oscillator_node::OscillatorNodeOptions;
 
 /// Type of AudioNodeEngine.
 #[derive(Debug, Clone)]
@@ -93,6 +93,9 @@ pub trait AudioNodeEngine: Send + AudioNodeCommon {
             AudioNodeMessage::SetChannelCount(c) => self.set_channel_count(c),
             AudioNodeMessage::SetChannelMode(c) => self.set_channel_count_mode(c),
             AudioNodeMessage::SetChannelInterpretation(c) => self.set_channel_interpretation(c),
+            AudioNodeMessage::SetParam(id, event) => {
+                self.get_param(id).insert_event(event.to_event(sample_rate))
+            }
             _ => self.message_specific(msg, sample_rate),
         }
     }
@@ -144,11 +147,10 @@ pub trait AudioNodeEngine: Send + AudioNodeCommon {
 pub enum AudioNodeMessage {
     AudioBufferSourceNode(AudioBufferSourceNodeMessage),
     AudioScheduledSourceNode(AudioScheduledSourceNodeMessage),
-    GainNode(GainNodeMessage),
-    OscillatorNode(OscillatorNodeMessage),
     SetChannelCount(u8),
     SetChannelMode(ChannelCountMode),
     SetChannelInterpretation(ChannelInterpretation),
+    SetParam(ParamType, UserAutomationEvent)
 }
 
 /// This trait represents the common features of the source nodes such as

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -1,3 +1,4 @@
+use audio::param::{Param, ParamType};
 use audio::channel_node::ChannelNodeOptions;
 use audio::block::{Chunk, Tick};
 use audio::buffer_source_node::{AudioBufferSourceNodeMessage, AudioBufferSourceNodeOptions};
@@ -83,6 +84,8 @@ pub trait AudioNodeCommon {
 
 /// This trait represents the common features of all audio nodes.
 pub trait AudioNodeEngine: Send + AudioNodeCommon {
+    fn node_type(&self) -> &'static str;
+
     fn process(&mut self, inputs: Chunk, info: &BlockInfo) -> Chunk;
 
     fn message(&mut self, msg: AudioNodeMessage, sample_rate: f32) {
@@ -130,6 +133,10 @@ pub trait AudioNodeEngine: Send + AudioNodeCommon {
     /// If we're the destination node, extract the contained data
     fn destination_data(&mut self) -> Option<Chunk> {
         None
+    }
+
+    fn get_param(&mut self, _: ParamType) -> &mut Param {
+        panic!("No params on node {}", self.node_type())
     }
 }
 

--- a/servo-media/src/audio/node.rs
+++ b/servo-media/src/audio/node.rs
@@ -76,14 +76,14 @@ impl Default for ChannelInfo {
 }
 
 
-pub trait AudioNodeCommon {
+pub(crate) trait AudioNodeCommon {
     fn channel_info(&self) -> &ChannelInfo;
 
     fn channel_info_mut(&mut self) -> &mut ChannelInfo;
 }
 
 /// This trait represents the common features of all audio nodes.
-pub trait AudioNodeEngine: Send + AudioNodeCommon {
+pub(crate) trait AudioNodeEngine: Send + AudioNodeCommon {
     fn node_type(&self) -> &'static str;
 
     fn process(&mut self, inputs: Chunk, info: &BlockInfo) -> Chunk;

--- a/servo-media/src/audio/oscillator_node.rs
+++ b/servo-media/src/audio/oscillator_node.rs
@@ -1,4 +1,4 @@
-use audio::node::ChannelInfo;
+use audio::node::{AudioNodeType, ChannelInfo};
 use audio::block::{Chunk, Tick};
 use audio::node::{AudioNodeEngine, AudioScheduledSourceNodeMessage, BlockInfo};
 use audio::param::{Param, ParamType};
@@ -80,7 +80,7 @@ impl OscillatorNode {
 
 impl AudioNodeEngine for OscillatorNode {
 
-    fn node_type(&self) -> &'static str { "OscillatorNode" }
+    fn node_type(&self) -> AudioNodeType { AudioNodeType::OscillatorNode }
 
     fn process(&mut self, mut inputs: Chunk, info: &BlockInfo) -> Chunk {
         // XXX Implement this properly and according to self.options

--- a/servo-media/src/audio/oscillator_node.rs
+++ b/servo-media/src/audio/oscillator_node.rs
@@ -38,7 +38,7 @@ impl Default for OscillatorNodeOptions {
 }
 
 #[derive(AudioScheduledSourceNode, AudioNodeCommon)]
-pub struct OscillatorNode {
+pub(crate) struct OscillatorNode {
     channel_info: ChannelInfo,
     frequency: Param,
     detune: Param,

--- a/servo-media/src/audio/oscillator_node.rs
+++ b/servo-media/src/audio/oscillator_node.rs
@@ -56,6 +56,7 @@ pub struct OscillatorNode {
 
 
 impl OscillatorNode {
+
     pub fn new(options: OscillatorNodeOptions) -> Self {
         Self {
             channel_info: Default::default(),
@@ -92,6 +93,9 @@ impl OscillatorNode {
 }
 
 impl AudioNodeEngine for OscillatorNode {
+
+    fn node_type(&self) -> &'static str { "OscillatorNode" }
+
     fn process(&mut self, mut inputs: Chunk, info: &BlockInfo) -> Chunk {
         // XXX Implement this properly and according to self.options
         // as defined in https://webaudio.github.io/web-audio-api/#oscillatornode

--- a/servo-media/src/audio/param.rs
+++ b/servo-media/src/audio/param.rs
@@ -6,6 +6,7 @@ pub enum ParamType {
     Frequency,
     Detune,
     Gain,
+    PlaybackRate
 }
 
 /// An AudioParam. 

--- a/servo-media/src/audio/param.rs
+++ b/servo-media/src/audio/param.rs
@@ -117,6 +117,12 @@ impl Param {
     }
 
     pub(crate) fn insert_event(&mut self, event: AutomationEvent) {
+        if let AutomationEvent::SetValue(val) = event {
+            self.val = val;
+            self.event_start_value = val;
+            return;
+        }
+
         let time = event.time();
 
         let result = self.events.binary_search_by(|e| e.time().cmp(&time));
@@ -156,6 +162,7 @@ pub enum RampKind {
 /// https://webaudio.github.io/web-audio-api/#dfn-automation-event
 pub(crate) enum AutomationEvent {
 
+    SetValue(f32),
     SetValueAtTime(f32, Tick),
     RampToValueAtTime(RampKind, f32, Tick),
     SetTargetAtTime(f32, Tick, /* time constant, units of Tick */ f64),
@@ -168,6 +175,7 @@ pub(crate) enum AutomationEvent {
 /// An AutomationEvent that uses times in s instead of Ticks
 pub enum UserAutomationEvent {
 
+    SetValue(f32),
     SetValueAtTime(f32, /* time */ f64),
     RampToValueAtTime(RampKind, f32, /* time */ f64),
     SetTargetAtTime(f32, f64, /* time constant, units of s */ f64),
@@ -179,6 +187,7 @@ pub enum UserAutomationEvent {
 impl UserAutomationEvent {
     pub(crate) fn to_event(self, rate: f32) -> AutomationEvent {
         match self {
+            UserAutomationEvent::SetValue(val) => AutomationEvent::SetValue(val),
             UserAutomationEvent::SetValueAtTime(val, time) =>
                 AutomationEvent::SetValueAtTime(val, Tick::from_time(time, rate)),
             UserAutomationEvent::RampToValueAtTime(kind, val, time) =>
@@ -202,8 +211,8 @@ impl AutomationEvent {
             AutomationEvent::RampToValueAtTime(_, _, tick) => tick,
             AutomationEvent::SetTargetAtTime(_, start, _) => start,
             AutomationEvent::CancelAndHoldAtTime(t) => t,
-            AutomationEvent::CancelScheduledValues(..) =>
-                unreachable!("CancelScheduledValues should never appear in the timeline"),
+            AutomationEvent::CancelScheduledValues(..) | AutomationEvent::SetValue(..) =>
+                unreachable!("CancelScheduledValues/SetValue should never appear in the timeline"),
         }
     }
 
@@ -213,8 +222,8 @@ impl AutomationEvent {
             AutomationEvent::RampToValueAtTime(_, _, tick) => Some(tick),
             AutomationEvent::SetTargetAtTime(..) => None,
             AutomationEvent::CancelAndHoldAtTime(t) => Some(t),
-            AutomationEvent::CancelScheduledValues(..) =>
-                unreachable!("CancelScheduledValues should never appear in the timeline"),
+            AutomationEvent::CancelScheduledValues(..) | AutomationEvent::SetValue(..) =>
+                unreachable!("CancelScheduledValues/SetValue should never appear in the timeline"),
         }
     }
 
@@ -224,8 +233,8 @@ impl AutomationEvent {
             AutomationEvent::RampToValueAtTime(..) => None,
             AutomationEvent::SetTargetAtTime(_, start, _) => Some(start),
             AutomationEvent::CancelAndHoldAtTime(t) => Some(t),
-            AutomationEvent::CancelScheduledValues(..) =>
-                unreachable!("CancelScheduledValues should never appear in the timeline"),
+            AutomationEvent::CancelScheduledValues(..) | AutomationEvent::SetValue(..) =>
+                unreachable!("CancelScheduledValues/SetValue should never appear in the timeline"),
         }
     }
 
@@ -284,8 +293,8 @@ impl AutomationEvent {
             AutomationEvent::CancelAndHoldAtTime(..) => {
                 false
             }
-            AutomationEvent::CancelScheduledValues(..) =>
-                unreachable!("CancelScheduledValues should never appear in the timeline"),
+            AutomationEvent::CancelScheduledValues(..) | AutomationEvent::SetValue(..) =>
+                unreachable!("CancelScheduledValues/SetValue should never appear in the timeline"),
         }
     }
 }

--- a/servo-media/src/audio/param.rs
+++ b/servo-media/src/audio/param.rs
@@ -1,6 +1,13 @@
 use audio::block::Tick;
 use audio::node::BlockInfo;
 
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub enum ParamType {
+    Frequency,
+    Detune,
+    Gain,
+}
+
 /// An AudioParam. 
 ///
 /// https://webaudio.github.io/web-audio-api/#AudioParam

--- a/servo-media/src/audio/render_thread.rs
+++ b/servo-media/src/audio/render_thread.rs
@@ -6,7 +6,7 @@ use audio::destination_node::DestinationNode;
 use audio::gain_node::GainNode;
 use audio::graph::{AudioGraph, NodeId, PortId, InputPort, OutputPort};
 use audio::node::BlockInfo;
-use audio::node::{AudioNodeEngine, AudioNodeMessage, AudioNodeType};
+use audio::node::{AudioNodeEngine, AudioNodeMessage, AudioNodeInit};
 use audio::oscillator_node::OscillatorNode;
 use audio::sink::AudioSink;
 use std::sync::mpsc::{Receiver, Sender};
@@ -16,7 +16,7 @@ use backends::gstreamer::audio_sink::GStreamerAudioSink;
 
 #[derive(Debug)]
 pub enum AudioRenderThreadMsg {
-    CreateNode(AudioNodeType, Sender<NodeId>),
+    CreateNode(AudioNodeInit, Sender<NodeId>),
     ConnectPorts(PortId<OutputPort>, PortId<InputPort>),
     MessageNode(NodeId, AudioNodeMessage),
     Resume(Sender<StateChangeResult>),
@@ -71,14 +71,14 @@ impl AudioRenderThread {
 
     make_render_thread_state_change!(suspend, Suspended, stop);
 
-    fn create_node(&mut self, node_type: AudioNodeType) -> NodeId {
+    fn create_node(&mut self, node_type: AudioNodeInit) -> NodeId {
         let node: Box<AudioNodeEngine> = match node_type {
-            AudioNodeType::AudioBufferSourceNode(options) => Box::new(AudioBufferSourceNode::new(options)),
-            AudioNodeType::DestinationNode => Box::new(DestinationNode::new()),
-            AudioNodeType::GainNode(options) => Box::new(GainNode::new(options)),
-            AudioNodeType::OscillatorNode(options) => Box::new(OscillatorNode::new(options)),
-            AudioNodeType::ChannelMergerNode(options) => Box::new(ChannelMergerNode::new(options)),
-            AudioNodeType::ChannelSplitterNode(options) => Box::new(ChannelSplitterNode::new(options)),
+            AudioNodeInit::AudioBufferSourceNode(options) => Box::new(AudioBufferSourceNode::new(options)),
+            AudioNodeInit::DestinationNode => Box::new(DestinationNode::new()),
+            AudioNodeInit::GainNode(options) => Box::new(GainNode::new(options)),
+            AudioNodeInit::OscillatorNode(options) => Box::new(OscillatorNode::new(options)),
+            AudioNodeInit::ChannelMergerNode(options) => Box::new(ChannelMergerNode::new(options)),
+            AudioNodeInit::ChannelSplitterNode(options) => Box::new(ChannelSplitterNode::new(options)),
             _ => unimplemented!(),
         };
         self.graph.add_node(node)


### PR DESCRIPTION
This adds a ParamType that lets us talk about AudioParams in a unified way. From the DOM side an `AudioParam` can now just be a `(NodeId, ParamType)` pair.

In the future we can use this to talk of connecting nodes to audio params as well, as an variant of PortId.

I also did some cleanups, marking engine-related things crate-public (script should never create engines), and renaming `AudioNodeType` to `AudioNodeInit` (this will require a rename in the DOM code) to better reflect what it does. `AudioNodeType` now exists as a bare enum for debugging purposes.

r? @ferjm