### PR TITLE
Turn off gstreamer for non-x86

### DIFF
--- a/servo-media/Cargo.toml
+++ b/servo-media/Cargo.toml
@@ -12,5 +12,5 @@ path = "../audio"
 [dependencies.servo-media-player]
 path = "../player"
 
-[target.'cfg(not(target_os = "android"))'.dependencies.servo-media-gstreamer]
+[target.'cfg(and(not(target_os = "android"), target_arch = "x86"))'.dependencies.servo-media-gstreamer]
 path = "../backends/gstreamer"

--- a/servo-media/src/lib.rs
+++ b/servo-media/src/lib.rs
@@ -1,5 +1,5 @@
 pub extern crate servo_media_audio as audio;
-#[cfg(not(target_os = "android"))]
+#[cfg(and(not(target_os = "android"), target_arch = "x86"))]
 extern crate servo_media_gstreamer;
 pub extern crate servo_media_player as player;
 use std::sync::{self, Arc, Mutex, Once};
@@ -37,9 +37,9 @@ impl PlayerBackend for DummyBackend {
     }
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(and(not(target_os = "android"), target_arch = "x86"))]
 pub type Backend = servo_media_gstreamer::GStreamerBackend;
-#[cfg(target_os = "android")]
+#cfg(not(and(not(target_os = "android"), target_arch = "x86")))]
 pub type Backend = DummyBackend;
 
 impl ServoMedia {


### PR DESCRIPTION
We don't have the ability to include it as a dependency on our CI right now.