### PR TITLE
Remove unused num-traits and fix lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,6 @@ dependencies = [
  "gstreamer-audio 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-player 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-media-audio 0.1.0",
  "servo-media-player 0.1.0",

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -10,9 +10,6 @@ zip = "0.3.1"
 [dependencies.byte-slice-cast]
 version = "0.1"
 
-[dependencies.num-traits]
-version = "0.2"
-
 [dependencies.glib]
 version = "0.5"
 


### PR DESCRIPTION
This completely remove an unused dependency from backends/gstreamer and fixes this build error:

```
error: failed to parse lock file at: /Users/ferjm/dev/mozilla/media/Cargo.lock

Caused by:
  package `num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)` is specified as a dependency, but is missing from the package list
```

r? @ceyusa 