### PR TITLE
Do not install old distro gstreamer-plugins-base on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,23 @@ addons:
     packages:
       - libpulse-dev
       - pulseaudio
+      - pulseaudio-utils
       - dbus-x11
-      - gstreamer1.0-plugins-base
+services:
+  - pulseaudio
 
 before_install:
-  - curl -L https://github.com/ferjm/gstreamer-1.14.1-ubuntu-trusty/raw/master/gstreamer.tar.gz | tar xz
-  - sed -i "s;prefix=/root/gstreamer;prefix=$PWD/gstreamer;g" $PWD/gstreamer/lib/x86_64-linux-gnu/pkgconfig/*.pc
-  - export PKG_CONFIG_PATH=$PWD/gstreamer/lib/x86_64-linux-gnu/pkgconfig
-  - export GST_PLUGIN_SYSTEM_PATH=$GST_PLUGIN_SYSTEM_PATH:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:$PWD/gstreamer/lib/x86_64-linux-gnu/gstreamer-1.0
-  - export GST_PLUGIN_SCANNER=$PWD/gstreamer/libexec/gstreamer-1.0/gst-plugin-scanner
-  - export PATH=$PATH:$PWD/gstreamer/bin
-  - export LD_LIBRARY_PATH=$PWD/gstreamer/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+  - curl -L https://github.com/ferjm/gstreamer-1.14.1-ubuntu-trusty/raw/master/gstreamer_.tar.gz | tar xz
+  - mv gstreamer /tmp/
+  - export PKG_CONFIG_PATH=/tmp/gstreamer/lib/x86_64-linux-gnu/pkgconfig
+  - export GST_PLUGIN_SYSTEM_PATH=$GST_PLUGIN_SYSTEM_PATH:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/tmp/gstreamer/lib/x86_64-linux-gnu/gstreamer-1.0
+  - export GST_PLUGIN_SCANNER=/tmp/gstreamer/libexec/gstreamer-1.0/gst-plugin-scanner
+  - export GST_REGISTRY=/tmp/gstreamer/registry.x86_64.bin
+  - export GST_REGISTRY_UPDATE=no
+  - export PATH=$PATH:/tmp/gstreamer/bin
+  - export LD_LIBRARY_PATH=/tmp/gstreamer/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
   - export DISPLAY=:99.0;
   - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
-  - dbus-launch pulseaudio --start;
 
 script:
   - cargo build

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,9 @@ before_install:
   - export PKG_CONFIG_PATH=/tmp/gstreamer/lib/x86_64-linux-gnu/pkgconfig
   - export GST_PLUGIN_SYSTEM_PATH=$GST_PLUGIN_SYSTEM_PATH:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/tmp/gstreamer/lib/x86_64-linux-gnu/gstreamer-1.0
   - export GST_PLUGIN_SCANNER=/tmp/gstreamer/libexec/gstreamer-1.0/gst-plugin-scanner
-  - export GST_REGISTRY=/tmp/gstreamer/registry.x86_64.bin
-  - export GST_REGISTRY_UPDATE=no
   - export PATH=$PATH:/tmp/gstreamer/bin
   - export LD_LIBRARY_PATH=/tmp/gstreamer/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+  - GST_REGISTRY_FORK=no /tmp/gstreamer/bin/gst-inspect-1.0 audiotestsrc
   - export DISPLAY=:99.0;
   - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
 


### PR DESCRIPTION
I've regenerated the binaries for Trusty to include the missing plugins, so we shouldn't need to install the system `gstreamer1.0-plugins-base` dep.