### PR TITLE
Don't require gstreamer on aarch64 android

### DIFF
--- a/servo-media/Cargo.toml
+++ b/servo-media/Cargo.toml
@@ -12,5 +12,5 @@ path = "../audio"
 [dependencies.servo-media-player]
 path = "../player"
 
-[target.'cfg(any(target_os = "android", target_arch = "x86_64"))'.dependencies.servo-media-gstreamer]
+[target.'cfg(any(all(target_os = "android", target_arch = "arm"), target_arch = "x86_64"))'.dependencies.servo-media-gstreamer]
 path = "../backends/gstreamer"

--- a/servo-media/src/lib.rs
+++ b/servo-media/src/lib.rs
@@ -1,5 +1,5 @@
 pub extern crate servo_media_audio as audio;
-#[cfg(any(target_os = "android", target_arch = "x86_64"))]
+#[cfg(any(all(target_os = "android", target_arch = "arm"), target_arch = "x86_64"))]
 extern crate servo_media_gstreamer;
 pub extern crate servo_media_player as player;
 use std::sync::{self, Arc, Mutex, Once};
@@ -40,14 +40,14 @@ impl DummyBackend {
     pub fn init() {}
 }
 
-#[cfg(any(target_os = "android", target_arch = "x86_64"))]
+#[cfg(any(all(target_os = "android", target_arch = "arm"), target_arch = "x86_64"))]
 pub type Backend = servo_media_gstreamer::GStreamerBackend;
-#[cfg(not(any(target_os = "android", target_arch = "x86_64")))]
+#[cfg(not(any(all(target_os = "android", target_arch = "arm"), target_arch = "x86_64")))]
 pub type Backend = DummyBackend;
 
-#[cfg(any(target_os = "android", target_arch = "x86_64"))]
+#[cfg(any(all(target_os = "android", target_arch = "arm"), target_arch = "x86_64"))]
 pub type Error = servo_media_gstreamer::BackendError;
-#[cfg(not(any(target_os = "android", target_arch = "x86_64")))]
+#[cfg(not(any(all(target_os = "android", target_arch = "arm"), target_arch = "x86_64")))]
 pub type Error = ();
 
 impl ServoMedia {


### PR DESCRIPTION
We're only supporting gstreamer on x86 and arm32 android, not arm64 android.