### PR TITLE
Only ignore gstreamer dir in root directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 **/target
 **/*.rs.bk
 **/wget-log
-gstreamer/
+/gstreamer/


### PR DESCRIPTION
Otherwise this silently ignores any new files under backends/gstreamer, which is not what we want.