### PR TITLE
Remove RateChanged player event

### DIFF
--- a/backends/gstreamer/src/player.rs
+++ b/backends/gstreamer/src/player.rs
@@ -401,16 +401,6 @@ impl GStreamerPlayer {
             .lock()
             .unwrap()
             .player
-            .connect_property_rate_notify(move |_| {
-                let inner = inner_clone.lock().unwrap();
-                inner.notify(PlayerEvent::RateChanged(inner.rate));
-            });
-
-        let inner_clone = inner.clone();
-        inner
-            .lock()
-            .unwrap()
-            .player
             .connect_duration_changed(move |_, duration| {
                 let duration = if duration != gst::ClockTime::none() {
                     let nanos = duration.nanoseconds();

--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -118,7 +118,6 @@ impl PlayerWrapper {
                         }
                         PlayerEvent::FrameUpdated => eprint!("."),
                         PlayerEvent::PositionChanged(_) => (),
-                        PlayerEvent::RateChanged(_) => (),
                         PlayerEvent::SeekData(_) => (),
                         PlayerEvent::SeekDone(_) => (),
                     }

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -130,9 +130,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
                     }
                 }
             },
-            PlayerEvent::RateChanged(r) => {
-                println!("\nRate changed to {:?}", r);
-            },
             PlayerEvent::SeekData(p) => {
                 println!("\nSeek requested to position {:?}", p);
                 seek_sender.send(p).unwrap();

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -24,7 +24,6 @@ pub enum PlayerEvent {
     FrameUpdated,
     MetadataUpdated(metadata::Metadata),
     PositionChanged(u64),
-    RateChanged(f64),
     /// The player needs the data to perform a seek to the given offset.
     /// The next push_data should get the buffers from the new offset.
     /// This event is only received for seekable stream types.


### PR DESCRIPTION
There is no way the playback rate can change unless the client changes it through the API, so this event is useless and unfortunately the cause of a deadlock.