### PR TITLE
Expose a way to implement a backoff protocol, refactor errors and other minor improvements

### DIFF
--- a/audio/src/context.rs
+++ b/audio/src/context.rs
@@ -142,7 +142,8 @@ impl<B: AudioBackend + 'static> AudioContext<B> {
                     graph,
                     options,
                 );
-            }).unwrap();
+            })
+            .unwrap();
         Self {
             sender,
             state: Cell::new(ProcessingState::Suspended),
@@ -251,11 +252,7 @@ impl<B: AudioBackend + 'static> AudioContext<B> {
 
     /// Asynchronously decodes the audio file data contained in the given
     /// buffer.
-    pub fn decode_audio_data(
-        &self,
-        data: Vec<u8>,
-        callbacks: AudioDecoderCallbacks<<B::Decoder as AudioDecoder>::Error>,
-    ) {
+    pub fn decode_audio_data(&self, data: Vec<u8>, callbacks: AudioDecoderCallbacks) {
         let mut options = AudioDecoderOptions::default();
         options.sample_rate = self.sample_rate;
         Builder::new()
@@ -264,7 +261,8 @@ impl<B: AudioBackend + 'static> AudioContext<B> {
                 let audio_decoder = B::make_decoder();
 
                 audio_decoder.decode(data, callbacks, Some(options));
-            }).unwrap();
+            })
+            .unwrap();
     }
 
     pub fn set_eos_callback(&self, callback: Box<Fn(Box<AsRef<[f32]>>) + Send + Sync + 'static>) {

--- a/audio/src/lib.rs
+++ b/audio/src/lib.rs
@@ -39,5 +39,5 @@ pub trait AudioBackend {
     type Decoder: decoder::AudioDecoder;
     type Sink: sink::AudioSink;
     fn make_decoder() -> Self::Decoder;
-    fn make_sink() -> Result<Self::Sink, <Self::Sink as sink::AudioSink>::Error>;
+    fn make_sink() -> Result<Self::Sink, sink::AudioSinkError>;
 }

--- a/audio/src/sink.rs
+++ b/audio/src/sink.rs
@@ -1,39 +1,46 @@
 use block::Chunk;
 use render_thread::AudioRenderThreadMsg;
-use std::fmt::Debug;
 use std::sync::mpsc::Sender;
 
+#[derive(Debug, PartialEq)]
+pub enum AudioSinkError {
+    /// Backend specific error.
+    Backend(String),
+    /// Could not push buffer into the audio sink.
+    BufferPushFailed,
+    /// Could not move to a different state.
+    StateChangeFailed,
+}
+
 pub trait AudioSink {
-    type Error: Debug;
     fn init(
         &self,
         sample_rate: f32,
         render_thread_channel: Sender<AudioRenderThreadMsg>,
-    ) -> Result<(), Self::Error>;
-    fn play(&self) -> Result<(), Self::Error>;
-    fn stop(&self) -> Result<(), Self::Error>;
+    ) -> Result<(), AudioSinkError>;
+    fn play(&self) -> Result<(), AudioSinkError>;
+    fn stop(&self) -> Result<(), AudioSinkError>;
     fn has_enough_data(&self) -> bool;
-    fn push_data(&self, chunk: Chunk) -> Result<(), Self::Error>;
+    fn push_data(&self, chunk: Chunk) -> Result<(), AudioSinkError>;
     fn set_eos_callback(&self, callback: Box<Fn(Box<AsRef<[f32]>>) + Send + Sync + 'static>);
 }
 
 pub struct DummyAudioSink;
 
 impl AudioSink for DummyAudioSink {
-    type Error = ();
-    fn init(&self, _: f32, _: Sender<AudioRenderThreadMsg>) -> Result<(), ()> {
+    fn init(&self, _: f32, _: Sender<AudioRenderThreadMsg>) -> Result<(), AudioSinkError> {
         Ok(())
     }
-    fn play(&self) -> Result<(), ()> {
+    fn play(&self) -> Result<(), AudioSinkError> {
         Ok(())
     }
-    fn stop(&self) -> Result<(), ()> {
+    fn stop(&self) -> Result<(), AudioSinkError> {
         Ok(())
     }
     fn has_enough_data(&self) -> bool {
         true
     }
-    fn push_data(&self, _: Chunk) -> Result<(), ()> {
+    fn push_data(&self, _: Chunk) -> Result<(), AudioSinkError> {
         Ok(())
     }
     fn set_eos_callback(&self, _: Box<Fn(Box<AsRef<[f32]>>) + Send + Sync + 'static>) {}

--- a/backends/gstreamer/src/lib.rs
+++ b/backends/gstreamer/src/lib.rs
@@ -11,39 +11,13 @@ extern crate ipc_channel;
 extern crate servo_media_audio;
 extern crate servo_media_player;
 
-use servo_media_audio::sink::AudioSink;
+use servo_media_audio::sink::AudioSinkError;
 use servo_media_audio::AudioBackend;
 use servo_media_player::PlayerBackend;
 
 pub mod audio_decoder;
 pub mod audio_sink;
 pub mod player;
-
-#[derive(Debug, PartialEq)]
-pub enum BackendError {
-    AudioInfoFailed,
-    BufferReadError,
-    Caps(&'static str),
-    ElementCreationFailed(&'static str),
-    EnoughData,
-    Flow(gst::FlowError),
-    GetStaticPadFailed(&'static str),
-    Gstreamer(gst::Error),
-    InvalidMediaFormat,
-    InvalidSample,
-    MissingElement(&'static str),
-    PadLinkFailed,
-    PipelineBusError(String),
-    PipelineFailed(&'static str),
-    PlayerError(String),
-    PlayerPushDataFailed,
-    PlayerEOSFailed,
-    PlayerNonSeekable,
-    PlayerSeekOutOfRange,
-    PlayerSourceSetupFailed,
-    SetPropertyFailed(&'static str),
-    StateChangeFailed,
-}
 
 pub struct GStreamerBackend;
 
@@ -53,7 +27,7 @@ impl AudioBackend for GStreamerBackend {
     fn make_decoder() -> Self::Decoder {
         audio_decoder::GStreamerAudioDecoder::new()
     }
-    fn make_sink() -> Result<Self::Sink, <Self::Sink as AudioSink>::Error> {
+    fn make_sink() -> Result<Self::Sink, AudioSinkError> {
         audio_sink::GStreamerAudioSink::new()
     }
 }

--- a/backends/gstreamer/src/lib.rs
+++ b/backends/gstreamer/src/lib.rs
@@ -19,12 +19,13 @@ pub mod audio_decoder;
 pub mod audio_sink;
 pub mod player;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum BackendError {
     AudioInfoFailed,
     BufferReadError,
     Caps(&'static str),
     ElementCreationFailed(&'static str),
+    EnoughData,
     Flow(gst::FlowError),
     GetStaticPadFailed(&'static str),
     Gstreamer(gst::Error),

--- a/backends/gstreamer/src/player.rs
+++ b/backends/gstreamer/src/player.rs
@@ -200,6 +200,9 @@ impl PlayerInner {
 
     pub fn push_data(&mut self, data: Vec<u8>) -> Result<(), BackendError> {
         if let Some(ref mut appsrc) = self.appsrc {
+            if appsrc.get_current_level_bytes() + data.len() as u64 >= appsrc.get_max_bytes() {
+                return Err(BackendError::EnoughData);
+            }
             let buffer =
                 gst::Buffer::from_slice(data).ok_or_else(|| BackendError::PlayerPushDataFailed)?;
             if appsrc.push_buffer(buffer) == gst::FlowReturn::Ok {

--- a/backends/gstreamer/src/player.rs
+++ b/backends/gstreamer/src/player.rs
@@ -199,7 +199,7 @@ impl PlayerInner {
 
     pub fn push_data(&mut self, data: Vec<u8>) -> Result<(), PlayerError> {
         if let Some(ref mut appsrc) = self.appsrc {
-            if appsrc.get_current_level_bytes() + data.len() as u64 >= appsrc.get_max_bytes() {
+            if appsrc.get_current_level_bytes() + data.len() as u64 > appsrc.get_max_bytes() {
                 return Err(PlayerError::EnoughData);
             }
             let buffer =
@@ -549,11 +549,9 @@ impl GStreamerPlayer {
                                 is_ready_.store(true, Ordering::Relaxed);
                                 let _ = sender_clone.lock().unwrap().send(Ok(()));
                             }
-                            println!("NEEEEEEEEEEED");
                             observers_.lock().unwrap().notify(PlayerEvent::NeedData);
                         })
                         .enough_data(move |_| {
-                            println!("ENOOOOOOOOUGH");
                             observers__.lock().unwrap().notify(PlayerEvent::EnoughData);
                         })
                         .seek_data(move |_, offset| {

--- a/backends/gstreamer/src/player.rs
+++ b/backends/gstreamer/src/player.rs
@@ -17,6 +17,8 @@ use std::sync::{Arc, Mutex};
 use std::time;
 use std::u64;
 
+const MAX_SRC_QUEUE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB.
+
 fn frame_from_sample(sample: &gst::Sample) -> Result<Frame, ()> {
     let buffer = sample.get_buffer().ok_or_else(|| ())?;
     let info = sample
@@ -473,6 +475,8 @@ impl GStreamerPlayer {
                     .clone()
                     .dynamic_cast::<gst_app::AppSrc>()
                     .expect("Source element is expected to be an appsrc!");
+
+                appsrc.set_max_bytes(MAX_SRC_QUEUE_SIZE);
 
                 appsrc.set_property_format(gst::Format::Bytes);
                 if inner.input_size > 0 {

--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -19,7 +19,6 @@ use gleam::gl;
 use ipc_channel::ipc;
 use servo_media::player::frame::{Frame, FrameRenderer};
 use servo_media::player::{Player, PlayerEvent};
-use servo_media::Error as ServoMediaError;
 use servo_media::ServoMedia;
 use std::env;
 use std::fs::File;
@@ -38,7 +37,7 @@ use webrender::api::*;
 mod ui;
 
 struct PlayerWrapper {
-    player: Arc<Mutex<Box<Player<Error = ServoMediaError>>>>,
+    player: Arc<Mutex<Box<Player>>>,
     shutdown: Arc<AtomicBool>,
 }
 
@@ -54,10 +53,7 @@ impl PlayerWrapper {
             .set_input_size(metadata.len())
             .unwrap();
         let (sender, receiver) = ipc::channel().unwrap();
-        player
-            .lock()
-            .unwrap()
-            .register_event_handler(sender);
+        player.lock().unwrap().register_event_handler(sender);
         let player_ = player.clone();
         let player__ = player.clone();
         let shutdown = Arc::new(AtomicBool::new(false));

--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -57,8 +57,7 @@ impl PlayerWrapper {
         player
             .lock()
             .unwrap()
-            .register_event_handler(sender)
-            .unwrap();
+            .register_event_handler(sender);
         let player_ = player.clone();
         let player__ = player.clone();
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -143,8 +142,7 @@ impl PlayerWrapper {
         self.player
             .lock()
             .unwrap()
-            .register_frame_renderer(renderer)
-            .unwrap();
+            .register_frame_renderer(renderer);
     }
 }
 

--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -120,6 +120,8 @@ impl PlayerWrapper {
                         PlayerEvent::PositionChanged(_) => (),
                         PlayerEvent::SeekData(_) => (),
                         PlayerEvent::SeekDone(_) => (),
+                        PlayerEvent::NeedData => (),
+                        PlayerEvent::EnoughData => (),
                     }
                 }
                 player.lock().unwrap().stop().unwrap();

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -63,7 +63,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
         let mut buf_reader = BufReader::new(file);
         let mut buffer = [0; 1024];
         let mut read = |offset| {
-            println!("READ {:?}", offset);
             if buf_reader.seek(SeekFrom::Start(offset)).is_err() {
                 eprintln!("BufReader - Could not seek to {:?}", offset);
             }

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -30,8 +30,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     player
         .lock()
         .unwrap()
-        .register_event_handler(sender)
-        .unwrap();
+        .register_event_handler(sender);
 
     let path = Path::new(filename);
     let display = path.display();

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -64,6 +64,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
         let mut buf_reader = BufReader::new(file);
         let mut buffer = [0; 1024];
         let mut read = |offset| {
+            println!("READ {:?}", offset);
             if buf_reader.seek(SeekFrom::Start(offset)).is_err() {
                 eprintln!("BufReader - Could not seek to {:?}", offset);
             }
@@ -87,7 +88,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
             }
         };
 
-        read(0);
         loop {
             if let Ok(position) = seek_receiver.try_recv() {
                 read(position);
@@ -100,6 +100,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     });
 
     player.lock().unwrap().play().unwrap();
+    seek_sender.send(0).unwrap();
 
     let mut seek_requested = false;
     while let Ok(event) = receiver.recv() {
@@ -129,12 +130,14 @@ fn run_example(servo_media: Arc<ServoMedia>) {
                         seek_requested = true;
                     }
                 }
-            },
+            }
             PlayerEvent::SeekData(p) => {
                 println!("\nSeek requested to position {:?}", p);
                 seek_sender.send(p).unwrap();
             }
             PlayerEvent::SeekDone(p) => println!("\nSeeked to {:?}", p),
+            PlayerEvent::NeedData => println!("\nNeedData"),
+            PlayerEvent::EnoughData => println!("\nEnoughData"),
         }
     }
 

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -50,12 +50,8 @@ pub enum StreamType {
 
 pub trait Player: Send {
     type Error: Debug;
-    fn register_event_handler(&self, sender: IpcSender<PlayerEvent>) -> Result<(), Self::Error>;
-    fn register_frame_renderer(
-        &self,
-        renderer: Arc<Mutex<frame::FrameRenderer>>,
-    ) -> Result<(), Self::Error>;
-
+    fn register_event_handler(&self, sender: IpcSender<PlayerEvent>);
+    fn register_frame_renderer(&self, renderer: Arc<Mutex<frame::FrameRenderer>>);
     fn play(&self) -> Result<(), Self::Error>;
     fn pause(&self) -> Result<(), Self::Error>;
     fn stop(&self) -> Result<(), Self::Error>;
@@ -72,12 +68,9 @@ pub struct DummyPlayer {}
 
 impl Player for DummyPlayer {
     type Error = ();
-    fn register_event_handler(&self, _: IpcSender<PlayerEvent>) -> Result<(), ()> {
-        Ok(())
+    fn register_event_handler(&self, _: IpcSender<PlayerEvent>) {
     }
-    fn register_frame_renderer(&self, _: Arc<Mutex<frame::FrameRenderer>>) -> Result<(), ()> {
-        Ok(())
-    }
+    fn register_frame_renderer(&self, _: Arc<Mutex<frame::FrameRenderer>>) {}
 
     fn play(&self) -> Result<(), ()> {
         Ok(())

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -20,9 +20,14 @@ pub enum PlaybackState {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum PlayerEvent {
     EndOfStream,
+    /// The player has enough data. The client should stop pushing data into.
+    EnoughData,
     Error,
     FrameUpdated,
     MetadataUpdated(metadata::Metadata),
+    /// The internal player queue is running out of data. The client should start
+    /// pushing more data.
+    NeedData,
     PositionChanged(u64),
     /// The player needs the data to perform a seek to the given offset.
     /// The next push_data should get the buffers from the new offset.

--- a/servo-media/src/lib.rs
+++ b/servo-media/src/lib.rs
@@ -1,12 +1,15 @@
 pub extern crate servo_media_audio as audio;
-#[cfg(any(all(target_os = "android", target_arch = "arm"), target_arch = "x86_64"))]
+#[cfg(any(
+    all(target_os = "android", target_arch = "arm"),
+    target_arch = "x86_64"
+))]
 extern crate servo_media_gstreamer;
 pub extern crate servo_media_player as player;
 use std::sync::{self, Arc, Mutex, Once};
 
 use audio::context::{AudioContext, AudioContextOptions};
 use audio::decoder::DummyAudioDecoder;
-use audio::sink::DummyAudioSink;
+use audio::sink::{AudioSinkError, DummyAudioSink};
 use audio::AudioBackend;
 use player::{DummyPlayer, Player, PlayerBackend};
 
@@ -24,7 +27,7 @@ impl AudioBackend for DummyBackend {
         DummyAudioDecoder
     }
 
-    fn make_sink() -> Result<Self::Sink, ()> {
+    fn make_sink() -> Result<Self::Sink, AudioSinkError> {
         Ok(DummyAudioSink)
     }
 }
@@ -40,15 +43,16 @@ impl DummyBackend {
     pub fn init() {}
 }
 
-#[cfg(any(all(target_os = "android", target_arch = "arm"), target_arch = "x86_64"))]
+#[cfg(any(
+    all(target_os = "android", target_arch = "arm"),
+    target_arch = "x86_64"
+))]
 pub type Backend = servo_media_gstreamer::GStreamerBackend;
-#[cfg(not(any(all(target_os = "android", target_arch = "arm"), target_arch = "x86_64")))]
+#[cfg(not(any(
+    all(target_os = "android", target_arch = "arm"),
+    target_arch = "x86_64"
+)))]
 pub type Backend = DummyBackend;
-
-#[cfg(any(all(target_os = "android", target_arch = "arm"), target_arch = "x86_64"))]
-pub type Error = servo_media_gstreamer::BackendError;
-#[cfg(not(any(all(target_os = "android", target_arch = "arm"), target_arch = "x86_64")))]
-pub type Error = ();
 
 impl ServoMedia {
     pub fn new() -> Self {
@@ -72,7 +76,7 @@ impl ServoMedia {
         AudioContext::new(options)
     }
 
-    pub fn create_player(&self) -> Box<Player<Error=Error>> {
+    pub fn create_player(&self) -> Box<Player> {
         Box::new(Backend::make_player())
     }
 }


### PR DESCRIPTION
This PR exposes the `EnoughData` and `NeedData` Player events that allow consumers to implement a backoff protocol.

I made a couple of significant refactors:

- I moved the list of Player observers and renderers out of `PlayerInner` to avoid deadlocks. For more information, you can read [this IRC conversation](https://mozilla.logbot.info/servo-media/20181219#c15742907-c15743272).
- I had to change the way we report errors in general to allow external consumption.