### PR TITLE
Use a Once per Player init

### DIFF
--- a/backends/gstreamer/src/player.rs
+++ b/backends/gstreamer/src/player.rs
@@ -16,7 +16,6 @@ use std::sync::{Arc, Mutex, Once};
 use std::time;
 use std::u64;
 
-static PLAYER_INIT: Once = Once::new();
 const MAX_SRC_QUEUE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB.
 
 fn frame_from_sample(sample: &gst::Sample) -> Result<Frame, ()> {
@@ -268,6 +267,9 @@ pub struct GStreamerPlayer {
     inner: RefCell<Option<Arc<Mutex<PlayerInner>>>>,
     observers: Arc<Mutex<PlayerEventObserverList>>,
     renderers: Arc<Mutex<FrameRendererList>>,
+    /// Indicates whether the setup was succesfully performed and
+    /// we are ready to consume a/v data.
+    is_ready: Arc<Once>,
 }
 
 impl GStreamerPlayer {
@@ -276,6 +278,7 @@ impl GStreamerPlayer {
             inner: RefCell::new(None),
             observers: Arc::new(Mutex::new(PlayerEventObserverList::new())),
             renderers: Arc::new(Mutex::new(FrameRendererList::new())),
+            is_ready: Arc::new(Once::new()),
         }
     }
 
@@ -498,6 +501,7 @@ impl GStreamerPlayer {
 
             let sender = Arc::new(Mutex::new(sender));
             let sender_clone = sender.clone();
+            let is_ready_clone = self.is_ready.clone();
             let observers = self.observers.clone();
             let connect_result = pipeline.connect("source-setup", false, move |args| {
                 let source = args[1].get::<gst::Element>();
@@ -528,6 +532,7 @@ impl GStreamerPlayer {
                 }
 
                 let sender_clone = sender.clone();
+                let is_ready_ = is_ready_clone.clone();
                 let observers_ = observers.clone();
                 let observers__ = observers.clone();
                 let observers___ = observers.clone();
@@ -539,7 +544,7 @@ impl GStreamerPlayer {
                             // don't miss any data between the moment the client
                             // calls setup and the player is actually ready to
                             // get any data.
-                            PLAYER_INIT.call_once(|| {
+                            is_ready_.call_once(|| {
                                 let _ = sender_clone.lock().unwrap().send(Ok(()));
                             });
                             observers_.lock().unwrap().notify(PlayerEvent::NeedData);


### PR DESCRIPTION
We need an init flag per Player instance, not a global flag. Regarding [this question](https://github.com/servo/media/pull/176#discussion_r244247665) I believe the usage of `Ordering::Relaxed` is fine here as it is harmless to send the unlock message twice.