### PR TITLE
Decouple playerwrapper for player test

### DIFF
--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -158,15 +158,7 @@ impl App {
 
 #[cfg(not(target_os = "android"))]
 impl ui::Example for App {
-    fn render(
-        &mut self,
-        api: &RenderApi,
-        builder: &mut DisplayListBuilder,
-        txn: &mut Transaction,
-        _framebuffer_size: DeviceUintSize,
-        _pipeline_id: PipelineId,
-        _document_id: DocumentId,
-    ) {
+    fn render(&mut self, api: &RenderApi, builder: &mut DisplayListBuilder, txn: &mut Transaction) {
         let frame = if self.frame_queue.is_empty() {
             if self.current_frame.is_none() {
                 return;

--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -16,18 +16,10 @@ extern crate webrender;
 extern crate winit;
 
 use gleam::gl;
-use ipc_channel::ipc;
 use servo_media::player::frame::{Frame, FrameRenderer};
-use servo_media::player::{Player, PlayerEvent};
-use servo_media::ServoMedia;
 use std::env;
-use std::fs::File;
-use std::io::BufReader;
-use std::io::Read;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::thread::Builder;
 #[cfg(not(target_os = "android"))]
 use ui::HandyDandyRectBuilder;
 use webrender::api::*;
@@ -36,111 +28,8 @@ use webrender::api::*;
 #[path = "ui.rs"]
 mod ui;
 
-struct PlayerWrapper {
-    player: Arc<Mutex<Box<Player>>>,
-    shutdown: Arc<AtomicBool>,
-}
-
-impl PlayerWrapper {
-    pub fn new(path: &Path) -> Self {
-        let servo_media = ServoMedia::get().unwrap();
-        let player = Arc::new(Mutex::new(servo_media.create_player()));
-        let file = File::open(&path).unwrap();
-        let metadata = file.metadata().unwrap();
-        player
-            .lock()
-            .unwrap()
-            .set_input_size(metadata.len())
-            .unwrap();
-        let (sender, receiver) = ipc::channel().unwrap();
-        player.lock().unwrap().register_event_handler(sender);
-        let player_ = player.clone();
-        let player__ = player.clone();
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let shutdown_ = shutdown.clone();
-        let shutdown__ = shutdown.clone();
-        Builder::new()
-            .name("File reader".to_owned())
-            .spawn(move || {
-                let player = &player_;
-                let shutdown = &shutdown_;
-                let mut buf_reader = BufReader::new(file);
-                let mut buffer = [0; 8192];
-                while !shutdown.load(Ordering::Relaxed) {
-                    match buf_reader.read(&mut buffer[..]) {
-                        Ok(0) => {
-                            println!("finished pushing data");
-                            break;
-                        }
-                        Ok(size) => {
-                            if let Err(_) = player
-                                .lock()
-                                .unwrap()
-                                .push_data(Vec::from(&buffer[0..size]))
-                            {
-                                break;
-                            }
-                        }
-                        Err(e) => {
-                            eprintln!("Error: {}", e);
-                            break;
-                        }
-                    }
-                }
-            })
-            .unwrap();
-
-        Builder::new()
-            .name("Player event loop".to_owned())
-            .spawn(move || {
-                let player = &player__;
-                let shutdown = &shutdown__;
-                while let Ok(event) = receiver.recv() {
-                    match event {
-                        PlayerEvent::EndOfStream => {
-                            println!("EOF");
-                            break;
-                        }
-                        PlayerEvent::Error => {
-                            println!("Error");
-                            break;
-                        }
-                        PlayerEvent::MetadataUpdated(ref m) => {
-                            println!("Metadata updated! {:?}", m);
-                        }
-                        PlayerEvent::StateChanged(ref s) => {
-                            println!("Player state changed to {:?}", s);
-                        }
-                        PlayerEvent::FrameUpdated => eprint!("."),
-                        PlayerEvent::PositionChanged(_) => (),
-                        PlayerEvent::SeekData(_) => (),
-                        PlayerEvent::SeekDone(_) => (),
-                        PlayerEvent::NeedData => (),
-                        PlayerEvent::EnoughData => (),
-                    }
-                }
-                player.lock().unwrap().stop().unwrap();
-                shutdown.store(true, Ordering::Relaxed);
-            })
-            .unwrap();
-
-        player.lock().unwrap().play().unwrap();
-
-        PlayerWrapper { player, shutdown }
-    }
-
-    fn shutdown(&self) {
-        self.player.lock().unwrap().stop().unwrap();
-        self.shutdown.store(true, Ordering::Relaxed);
-    }
-
-    fn register_frame_renderer(&self, renderer: Arc<Mutex<FrameRenderer>>) {
-        self.player
-            .lock()
-            .unwrap()
-            .register_frame_renderer(renderer);
-    }
-}
+#[path = "player_wrapper.rs"]
+mod player_wrapper;
 
 struct App {
     frame_queue: Vec<Frame>,
@@ -158,7 +47,12 @@ impl App {
 
 #[cfg(not(target_os = "android"))]
 impl ui::Example for App {
-    fn render(&mut self, api: &RenderApi, builder: &mut DisplayListBuilder, txn: &mut Transaction) {
+    fn push_txn(
+        &mut self,
+        api: &RenderApi,
+        builder: &mut DisplayListBuilder,
+        txn: &mut Transaction,
+    ) {
         let frame = if self.frame_queue.is_empty() {
             if self.current_frame.is_none() {
                 return;
@@ -240,9 +134,6 @@ fn main() {
     };
 
     let path = Path::new(filename);
-    let player_wrapper = PlayerWrapper::new(&path);
     let app = Arc::new(Mutex::new(App::new()));
-    player_wrapper.register_frame_renderer(app.clone());
-    ui::main_wrapper(app, None);
-    player_wrapper.shutdown();
+    ui::main_wrapper(app, &path, None);
 }

--- a/examples/player/player_wrapper.rs
+++ b/examples/player/player_wrapper.rs
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use ipc_channel::ipc;
+use servo_media::player::frame::{Frame, FrameRenderer};
+use servo_media::player::{Player, PlayerEvent};
+use servo_media::ServoMedia;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::Builder;
+
+pub struct PlayerWrapper {
+    player: Arc<Mutex<Box<Player>>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl PlayerWrapper {
+    pub fn new(path: &Path) -> Self {
+        let servo_media = ServoMedia::get().unwrap();
+        let player = Arc::new(Mutex::new(servo_media.create_player()));
+        let file = File::open(&path).unwrap();
+        let metadata = file.metadata().unwrap();
+        player
+            .lock()
+            .unwrap()
+            .set_input_size(metadata.len())
+            .unwrap();
+        let (sender, receiver) = ipc::channel().unwrap();
+        player.lock().unwrap().register_event_handler(sender);
+        let player_ = player.clone();
+        let player__ = player.clone();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_ = shutdown.clone();
+        let shutdown__ = shutdown.clone();
+        Builder::new()
+            .name("File reader".to_owned())
+            .spawn(move || {
+                let player = &player_;
+                let shutdown = &shutdown_;
+                let mut buf_reader = BufReader::new(file);
+                let mut buffer = [0; 8192];
+                while !shutdown.load(Ordering::Relaxed) {
+                    match buf_reader.read(&mut buffer[..]) {
+                        Ok(0) => {
+                            println!("finished pushing data");
+                            break;
+                        }
+                        Ok(size) => {
+                            if let Err(_) = player
+                                .lock()
+                                .unwrap()
+                                .push_data(Vec::from(&buffer[0..size]))
+                            {
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Error: {}", e);
+                            break;
+                        }
+                    }
+                }
+            })
+            .unwrap();
+
+        Builder::new()
+            .name("Player event loop".to_owned())
+            .spawn(move || {
+                let player = &player__;
+                let shutdown = &shutdown__;
+                while let Ok(event) = receiver.recv() {
+                    match event {
+                        PlayerEvent::EndOfStream => {
+                            println!("EOF");
+                            break;
+                        }
+                        PlayerEvent::Error => {
+                            println!("Error");
+                            break;
+                        }
+                        PlayerEvent::MetadataUpdated(ref m) => {
+                            println!("Metadata updated! {:?}", m);
+                        }
+                        PlayerEvent::StateChanged(ref s) => {
+                            println!("Player state changed to {:?}", s);
+                        }
+                        PlayerEvent::FrameUpdated => eprint!("."),
+                        PlayerEvent::PositionChanged(_) => (),
+                        PlayerEvent::SeekData(_) => (),
+                        PlayerEvent::SeekDone(_) => (),
+                        PlayerEvent::NeedData => (),
+                        PlayerEvent::EnoughData => (),
+                    }
+                }
+                player.lock().unwrap().stop().unwrap();
+                shutdown.store(true, Ordering::Relaxed);
+            })
+            .unwrap();
+
+        player.lock().unwrap().play().unwrap();
+
+        PlayerWrapper { player, shutdown }
+    }
+
+    pub fn shutdown(&self) {
+        self.player.lock().unwrap().stop().unwrap();
+        self.shutdown.store(true, Ordering::Relaxed);
+    }
+
+    pub fn register_frame_renderer(&self, renderer: Arc<Mutex<FrameRenderer>>) {
+        self.player
+            .lock()
+            .unwrap()
+            .register_frame_renderer(renderer);
+    }
+}

--- a/examples/player/ui.rs
+++ b/examples/player/ui.rs
@@ -10,7 +10,6 @@ extern crate euclid;
 use gleam::gl;
 use glutin::{self, GlContext};
 use std::env;
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use webrender;
 use webrender::api::*;
@@ -110,13 +109,6 @@ pub fn main_wrapper<E: Example>(
 ) {
     env_logger::init();
 
-    let args: Vec<String> = env::args().collect();
-    let res_path = if args.len() > 1 {
-        Some(PathBuf::from(&args[1]))
-    } else {
-        None
-    };
-
     let mut events_loop = winit::EventsLoop::new();
     let context_builder = glutin::ContextBuilder::new().with_gl(glutin::GlRequest::GlThenGles {
         opengl_version: (3, 2),
@@ -146,13 +138,12 @@ pub fn main_wrapper<E: Example>(
     };
 
     println!("OpenGL version {}", gl.get_string(gl::VERSION));
-    println!("Shader resource path: {:?}", res_path);
     let device_pixel_ratio = window.get_hidpi_factor() as f32;
     println!("Device pixel ratio: {}", device_pixel_ratio);
 
     println!("Loading shaders...");
     let opts = webrender::RendererOptions {
-        resource_override_path: res_path,
+        resource_override_path: None,
         precache_shaders: E::PRECACHE_SHADERS,
         device_pixel_ratio,
         clear_color: Some(ColorF::new(0.3, 0.0, 0.0, 1.0)),

--- a/examples/player/ui.rs
+++ b/examples/player/ui.rs
@@ -76,15 +76,7 @@ pub trait Example {
     const WIDTH: u32 = 1920;
     const HEIGHT: u32 = 1080;
 
-    fn render(
-        &mut self,
-        api: &RenderApi,
-        builder: &mut DisplayListBuilder,
-        txn: &mut Transaction,
-        framebuffer_size: DeviceUintSize,
-        pipeline_id: PipelineId,
-        document_id: DocumentId,
-    );
+    fn render(&mut self, api: &RenderApi, builder: &mut DisplayListBuilder, txn: &mut Transaction);
     fn on_event(&self, winit::WindowEvent, &RenderApi, DocumentId) -> bool {
         false
     }
@@ -180,14 +172,7 @@ pub fn main_wrapper<E: Example>(
     let mut builder = DisplayListBuilder::new(pipeline_id, layout_size);
     let mut txn = Transaction::new();
 
-    example.lock().unwrap().render(
-        &api,
-        &mut builder,
-        &mut txn,
-        framebuffer_size,
-        pipeline_id,
-        document_id,
-    );
+    example.lock().unwrap().render(&api, &mut builder, &mut txn);
     txn.set_display_list(epoch, None, layout_size, builder.finalize(), true);
     txn.set_root_pipeline(pipeline_id);
     txn.generate_frame();
@@ -272,14 +257,7 @@ pub fn main_wrapper<E: Example>(
         if custom_event || example.lock().unwrap().needs_repaint() {
             let mut builder = DisplayListBuilder::new(pipeline_id, layout_size);
 
-            example.lock().unwrap().render(
-                &api,
-                &mut builder,
-                &mut txn,
-                framebuffer_size,
-                pipeline_id,
-                document_id,
-            );
+            example.lock().unwrap().render(&api, &mut builder, &mut txn);
             txn.set_display_list(epoch, None, layout_size, builder.finalize(), true);
             txn.generate_frame();
         }


### PR DESCRIPTION
In order to configure the test player to use GL rendering, it's required to pass GL parameters from the application to the player, before its configuration. Because of that the player must be instantiated after the UI is launched.

This PR does this.

I think it's better to merge it soon in order to avoid more complex rebases later :)