### PR TITLE
Negotiate  GL textures and render them in player example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
  "env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin 0.19.0 (git+https://github.com/tomaka/glutin)",
  "hyper 0.12.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "glutin"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tomaka/glutin#c16f997e4c6898bc3a3603c74c341c2a5497839c"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2485,7 +2485,7 @@ dependencies = [
 "checksum gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4b47f5b15742aee359c7895ab98cf2cceecc89bb4feb6f4e42f802d7899877da"
 "checksum glib 0.6.0 (git+https://github.com/gtk-rs/glib)" = "<none>"
 "checksum glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)" = "<none>"
-"checksum glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "535c6eda58adbb227604b2db10a022ffd6339d7ea3e970f338e7d98aeb24fcc3"
+"checksum glutin 0.19.0 (git+https://github.com/tomaka/glutin)" = "<none>"
 "checksum gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)" = "<none>"
 "checksum gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
 "checksum gstreamer-app 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,11 +563,11 @@ dependencies = [
 [[package]]
 name = "glib"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/gtk-rs/glib#d6a3b037656ed3f18218e7bd5d2254e66134669d"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "glib-sys"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/gtk-rs/sys#c68dace3c4e28bf936781f0b836c88f852cb2e9e"
 dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -604,55 +604,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "gobject-subclass"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "gobject-sys"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/gtk-rs/sys#c68dace3c4e28bf936781f0b836c88f852cb2e9e"
 dependencies = [
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "gst-plugin"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-subclass 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-base 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-base-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "gstreamer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.13.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a5a016557ff6c5aafcd58ecf6d2f3ed91ed2325a"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.6.0 (git+https://github.com/gtk-rs/glib)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "muldiv 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -661,208 +632,209 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-app"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.13.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a5a016557ff6c5aafcd58ecf6d2f3ed91ed2325a"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-app-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-base 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-base-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.6.0 (git+https://github.com/gtk-rs/glib)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-app-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-base 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-base-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-app-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys#e73bc4d9cdc02520e3346361ed5da1f7b126fb50"
 dependencies = [
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-base-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer-base-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-audio"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.13.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a5a016557ff6c5aafcd58ecf6d2f3ed91ed2325a"
 dependencies = [
  "array-init 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-audio-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.6.0 (git+https://github.com/gtk-rs/glib)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-audio-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
 ]
 
 [[package]]
 name = "gstreamer-audio-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys#e73bc4d9cdc02520e3346361ed5da1f7b126fb50"
 dependencies = [
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-base-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer-base-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-base"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.13.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a5a016557ff6c5aafcd58ecf6d2f3ed91ed2325a"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-base-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.6.0 (git+https://github.com/gtk-rs/glib)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-base-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-base-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys#e73bc4d9cdc02520e3346361ed5da1f7b126fb50"
 dependencies = [
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-player"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.13.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a5a016557ff6c5aafcd58ecf6d2f3ed91ed2325a"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-player-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-video 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.6.0 (git+https://github.com/gtk-rs/glib)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-player-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-video 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-player-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys#e73bc4d9cdc02520e3346361ed5da1f7b126fb50"
 dependencies = [
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-video-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-video-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-sdp"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.13.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a5a016557ff6c5aafcd58ecf6d2f3ed91ed2325a"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sdp-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.6.0 (git+https://github.com/gtk-rs/glib)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-sdp-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-sdp-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys#e73bc4d9cdc02520e3346361ed5da1f7b126fb50"
 dependencies = [
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys#e73bc4d9cdc02520e3346361ed5da1f7b126fb50"
 dependencies = [
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-video"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.13.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a5a016557ff6c5aafcd58ecf6d2f3ed91ed2325a"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-base 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-base-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-video-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.6.0 (git+https://github.com/gtk-rs/glib)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-base 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-base-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-video-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-video-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys#e73bc4d9cdc02520e3346361ed5da1f7b126fb50"
 dependencies = [
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-base-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer-base-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-webrtc"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.13.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a5a016557ff6c5aafcd58ecf6d2f3ed91ed2325a"
 dependencies = [
- "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sdp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-webrtc-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.6.0 (git+https://github.com/gtk-rs/glib)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-sdp 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-webrtc-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gstreamer-webrtc-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys#e73bc4d9cdc02520e3346361ed5da1f7b126fb50"
 dependencies = [
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sdp-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer-sdp-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1663,19 +1635,16 @@ version = "0.1.0"
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-subclass 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gst-plugin 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-app 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-audio 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-player 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sdp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-video 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-webrtc 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.6.0 (git+https://github.com/gtk-rs/glib)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-app 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-audio 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-player 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-sdp 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-video 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-webrtc 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
  "ipc-channel 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2463,28 +2432,26 @@ dependencies = [
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0ffaf173cf76c73a73e080366bf556b4776ece104b06961766ff11449f38604"
 "checksum gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4b47f5b15742aee359c7895ab98cf2cceecc89bb4feb6f4e42f802d7899877da"
-"checksum glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740f7fda8dde5f5e3944dabdb4a73ac6094a8a7fdf0af377468e98ca93733e61"
-"checksum glib-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3573351e846caed9f11207b275cd67bc07f0c2c94fb628e5d7c92ca056c7882d"
+"checksum glib 0.6.0 (git+https://github.com/gtk-rs/glib)" = "<none>"
+"checksum glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)" = "<none>"
 "checksum glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "535c6eda58adbb227604b2db10a022ffd6339d7ea3e970f338e7d98aeb24fcc3"
-"checksum gobject-subclass 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23a365ac97171d914fc0f2ccf86f3a05ae4ee870427eee9c82f6bb95bbf201b6"
-"checksum gobject-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08475e4a08f27e6e2287005950114735ed61cec2cb8c1187682a5aec8c69b715"
-"checksum gst-plugin 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0211cec5228a72501a912a45b43d5450db7bc20d14e68631786ac8270908b8d"
-"checksum gstreamer 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df451f98ea8b987b5fc1b647b9f038ca6ea106b08c3bccc1ef3126d4f0a687c1"
-"checksum gstreamer-app 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f4f865cf7f22c66907372a2e3b0f0ced3d3fedab823641d6667d2568be71408"
-"checksum gstreamer-app-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0b8319fe7a8a015412a76a56b248a3c68561a39225a3fa0fcbb58aab8e12392"
-"checksum gstreamer-audio 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6161fdafd1211ebcf332cbeb0026dcde297d2f5f211ca99c5c0c90c445dcff8"
-"checksum gstreamer-audio-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5266ec77146be5279a90d49794339377bc2f78883fd044366261ac9cfac9d6e5"
-"checksum gstreamer-base 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4a68e3ee44369208fb27acc94defd10e4e8bc2ae8be77b0a85f90a0cf8bd6fd8"
-"checksum gstreamer-base-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1eb57a7d013604ab7af2b843b62b13b8fb30f22d066919f7e198f528c3296cd0"
-"checksum gstreamer-player 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1144c6c5c3af25dd1f89b4f9d2762f1c2d8789e65cdc79e2451dd24350d84dd2"
-"checksum gstreamer-player-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e642cb58d3733e2724def7186101bb00144fc97d45b2c379eba6d0c0662dec"
-"checksum gstreamer-sdp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ade1226bb5a0622125e49f1a801ac6b673986d96513862ff0b1f21b0b3595ae"
-"checksum gstreamer-sdp-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "816628556bc2c9a627efd6e7d9b67ab4abb246b143bff2b3ad7fff6923f11cb1"
-"checksum gstreamer-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3aec69f30ab98a7b0cf4a29179eeffa8a1e7d6062f5ee55e9792917cb0980bda"
-"checksum gstreamer-video 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c1f04816d7e183714830da26274f97e7aeff09ae6641058538d21443b4ec07d"
-"checksum gstreamer-video-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e2efb301a0b94fa4af503122faa04247085936dd888fd59fa4e21eab3cbd37"
-"checksum gstreamer-webrtc 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f7fc9422d65781cfe8d2f9994b1010476ce0839b8fce7db97eb87bdf75b614e"
-"checksum gstreamer-webrtc-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "38a27025af94512f0d798ff9dd0b269951ce305879873c4ab6266885c7bd207f"
+"checksum gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)" = "<none>"
+"checksum gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
+"checksum gstreamer-app 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
+"checksum gstreamer-app-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
+"checksum gstreamer-audio 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
+"checksum gstreamer-audio-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
+"checksum gstreamer-base 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
+"checksum gstreamer-base-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
+"checksum gstreamer-player 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
+"checksum gstreamer-player-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
+"checksum gstreamer-sdp 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
+"checksum gstreamer-sdp-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
+"checksum gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
+"checksum gstreamer-video 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
+"checksum gstreamer-video-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
+"checksum gstreamer-webrtc 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
+"checksum gstreamer-webrtc-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
 "checksum h2 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7dd33bafe2e6370e6c8eb0cf1b8c5f93390b90acde7e9b03723f166b28b648ed"
 "checksum http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "24f58e8c2d8e886055c3ead7b28793e1455270b5fb39650984c224bc538ba581"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "gstreamer-gl"
+version = "0.13.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a5a016557ff6c5aafcd58ecf6d2f3ed91ed2325a"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.6.0 (git+https://github.com/gtk-rs/glib)",
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-base 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-base-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-gl-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-video 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-video-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gstreamer-gl-sys"
+version = "0.7.0"
+source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys#e73bc4d9cdc02520e3346361ed5da1f7b126fb50"
+dependencies = [
+ "glib-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gobject-sys 0.7.0 (git+https://github.com/gtk-rs/sys)",
+ "gstreamer-base-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "gstreamer-video-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gstreamer-player"
 version = "0.13.0"
 source = "git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs#a5a016557ff6c5aafcd58ecf6d2f3ed91ed2325a"
@@ -1679,6 +1714,7 @@ dependencies = [
  "gstreamer 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
  "gstreamer-app 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
  "gstreamer-audio 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
+ "gstreamer-gl 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
  "gstreamer-player 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
  "gstreamer-sdp 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)",
  "gstreamer-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)",
@@ -2494,6 +2530,8 @@ dependencies = [
 "checksum gstreamer-audio-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
 "checksum gstreamer-base 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
 "checksum gstreamer-base-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
+"checksum gstreamer-gl 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
+"checksum gstreamer-gl-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
 "checksum gstreamer-player 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"
 "checksum gstreamer-player-sys 0.7.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys)" = "<none>"
 "checksum gstreamer-sdp 0.13.0 (git+https://gitlab.freedesktop.org/gstreamer/gstreamer-rs)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -107,7 +107,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -126,6 +126,25 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "block-buffer"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "boxfnonce"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +157,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "byte-slice-cast"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -219,7 +243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -246,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -268,33 +292,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "core-graphics"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "core-graphics"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "core-text"
-version = "11.0.0"
+version = "13.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -378,6 +391,14 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "digest"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dlib"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,16 +413,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dwrote"
-version = "0.4.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -428,11 +447,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "euclid"
-version = "0.19.0"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "euclid_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "euclid_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -440,21 +470,26 @@ name = "examples"
 version = "0.1.0"
 dependencies = [
  "env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-media 0.1.0",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.57.2 (git+https://github.com/servo/webrender/?rev=c939a61b)",
+ "webrender 0.58.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fixedbitset"
@@ -534,12 +569,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "gdi32-sys"
-version = "0.2.0"
+name = "generic-array"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -589,7 +623,7 @@ dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -959,7 +993,7 @@ dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1263,6 +1297,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "openssl"
 version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,11 +1394,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "plane-split"
-version = "0.12.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "binary-space-partition 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1559,10 +1598,10 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.66"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1570,17 +1609,17 @@ name = "serde_bytes"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.66"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1590,7 +1629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1619,12 +1658,12 @@ version = "0.1.0"
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_media_derive 0.1.0",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1661,8 +1700,8 @@ name = "servo-media-player"
 version = "0.1.0"
 dependencies = [
  "ipc-channel 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1698,6 +1737,17 @@ dependencies = [
 name = "sha1"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sha2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "shared_library"
@@ -1755,16 +1805,6 @@ dependencies = [
 name = "string"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "syn"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "syn"
@@ -2037,6 +2077,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ucd-util"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,49 +2233,50 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.57.2"
-source = "git+https://github.com/servo/webrender/?rev=c939a61b#c939a61b83bcc9dc10742977704793e9a85b3858"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dwrote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 13.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dwrote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "plane-split 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plane-split 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_api 0.57.2 (git+https://github.com/servo/webrender/?rev=c939a61b)",
+ "webrender_api 0.58.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "webrender_api"
-version = "0.57.2"
-source = "git+https://github.com/servo/webrender/?rev=c939a61b#c939a61b83bcc9dc10742977704793e9a85b3858"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dwrote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dwrote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2308,7 +2354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2381,9 +2427,12 @@ dependencies = [
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+"checksum block-buffer 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "509de513cca6d92b6aacf9c61acfe7eaa160837323a81068d690cc1f8e5740da"
+"checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
 "checksum boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbec60c560f322d8e3cd403f91d8908cfd965fff53ba97154bd1b9d90149d98e"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28346c117b50270785fbc123bd6e4ecad20d0c6d5f43d081dc80a3abcc62be64"
+"checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8389c509ec62b9fe8eca58c502a0acaf017737355615243496cde4994f8fa4f9"
 "checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
 "checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
@@ -2397,12 +2446,11 @@ dependencies = [
 "checksum cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf79daa4e11e5def06e55306aa3601b87de6b5149671529318da048f67cdd77b"
 "checksum combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1645a65a99c7c8d345761f4b75a6ffe5be3b3b27a93ee731fccc5050ba6be97c"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
-"checksum core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cc3532ec724375c7cb7ff0a097b714fde180bb1f6ed2ab27cfcd99ffca873cd2"
+"checksum core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2640d6d0bf22e82bed1b73c6aef8d5dd31e5abe6666c57e6d45e2649f4f887"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum core-foundation-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a3fb15cdbdd9cf8b82d97d0296bb5cd3631bba58d6e31650a002a8e7fb5721f9"
-"checksum core-graphics 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92801c908ea6301ae619ed842a72e01098085fc321b9c2f3f833dad555bba055"
 "checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
-"checksum core-text 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "157ff38a92496dc676ce36d9124554e9ac66f1c1039f952690ac64f71cfa5968"
+"checksum core-text 13.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7210eea4baa4b51d7319d90e4787d8a2b472c8d5d9926dc39be85fecac0e6df7"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crossbeam-channel 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6c0a94250b0278d7fc5a894c3d276b11ea164edc8bf8feb10ca1ea517b44a649"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
@@ -2411,13 +2459,16 @@ dependencies = [
 "checksum crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30fecfcac6abfef8771151f8be4abc9e4edc112c2bcb233314cafde2680536e9"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
+"checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "18df8ce4470c189d18aa926022da57544f31e154631eb4cfe796aea97051fe6c"
-"checksum dwrote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b26e30aaa6bf31ec830db15fec14ed04f0f2ecfcc486ecfce88c55d3389b237f"
+"checksum dwrote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f0beca78470f26189a662e72afe7a54c625b4feb06b2d36c207ac15319bd57c5"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f4d7e69c283751083d53d01eac767407343b8b69c4bd70058e08adc2637cb257"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
-"checksum euclid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "70a2ebdf55fb9d6329046e026329a55ef8fbaae5ea833f56e170beb3125a8a5f"
+"checksum euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d1a7698bdda3d7444a79d33bdc96e8b518d44ea3ff101d8492a6ca1207b886ea"
+"checksum euclid_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdcb84c18ea5037a1c5a23039b4ff29403abce2e0d6b1daa11cf0bde2b30be15"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fac2277e84e5e858483756647a9d0aa8d9a2b7cba517fd84325a0aaa69a0909"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -2429,7 +2480,7 @@ dependencies = [
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-"checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
+"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0ffaf173cf76c73a73e080366bf556b4776ece104b06961766ff11449f38604"
 "checksum gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4b47f5b15742aee359c7895ab98cf2cceecc89bb4feb6f4e42f802d7899877da"
 "checksum glib 0.6.0 (git+https://github.com/gtk-rs/glib)" = "<none>"
@@ -2499,6 +2550,7 @@ dependencies = [
 "checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9833ab0efe5361b1e2122a0544a5d3359576911a42cb098c2e59be8650807367"
+"checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-sys 0.9.39 (registry+https://github.com/rust-lang/crates.io-index)" = "278c1ad40a89aa1e741a1eed089a2f60b18fab8089c3139b542140fc7d674106"
 "checksum ordered-float 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0015e9e8e28ee20c581cfbfe47c650cedeb9ed0721090e0b7ebb10b9cdbcc2"
@@ -2510,7 +2562,7 @@ dependencies = [
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "6a52e4dbc8354505ee07e484ab07127e06d87ca6fa7f0a516a2b294e5ad5ad16"
-"checksum plane-split 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ff3a4fc9e31d70eb6828e9a2d7a401a824d9f281686a39a8fc06f08796edb1bb"
+"checksum plane-split 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9b1d9a84aa3bbc2dafd06856bdb1dc333eb1d442ad8987b9d596c7344b3ed969"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "cccdc7557a98fe98453030f077df7f3a042052fae465bb61d2c2c41435cfd9b6"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -2535,12 +2587,13 @@ dependencies = [
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfa44ee9c54ce5eecc9de7d5acbad112ee58755239381f687e564004ba4a2332"
 "checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
-"checksum serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "e9a2d9a9ac5120e0f768801ca2b58ad6eec929dc9d1d616c162f208869c2ce95"
+"checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 "checksum serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adb6e51a6b3696b301bc221d785f898b4457c619b51d7ce195a6d20baecb37b3"
-"checksum serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "0a90213fa7e0f5eac3f7afe2d5ff6b088af515052cc7303bd68c7e3b91a3fb79"
+"checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
 "checksum servo-freetype-sys 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9232032c2e85118c0282c6562c84cab12316e655491ba0a5d1905b2320060d1b"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
+"checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "26df3bb03ca5eac2e64192b723d51f56c1b1e0860e7c766281f4598f181acdc8"
@@ -2548,7 +2601,6 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stb_truetype 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "48fa7d3136d8645909de1f7c7eb5416cc43057a75ace08fc39ae736bc9da8af1"
 "checksum string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00caf261d6f90f588f8450b8e1230fa0d5be49ee6140fdfbcb55335aff350970"
-"checksum syn 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e13df71f29f9440b50261a5882c86eac334f1badb3134ec26f0de2f1418e44"
 "checksum syn 0.15.17 (registry+https://github.com/rust-lang/crates.io-index)" = "3391038ebc3e4ab24eb028cb0ef2f2dc4ba0cbf72ee895ed6a6fad730640b5bc"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c4b103c6d08d323b92ff42c8ce62abcd83ca8efa7fd5bf7927efefec75f58c76"
@@ -2574,6 +2626,7 @@ dependencies = [
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
@@ -2593,8 +2646,8 @@ dependencies = [
 "checksum wayland-protocols 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f6cebb98963f028d397e9bad2acf9d3b2f6b76fae65aea191edd9e7c0df88c"
 "checksum wayland-scanner 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f1927ee62e4e149c010dc9eca8ca47e238416cd6f45f688eb9f8a8e9c3794c30"
 "checksum wayland-sys 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ca41ed78a12256f81df6f53fcbe4503213ba442e02cdad3c9c888a64a668eaf4"
-"checksum webrender 0.57.2 (git+https://github.com/servo/webrender/?rev=c939a61b)" = "<none>"
-"checksum webrender_api 0.57.2 (git+https://github.com/servo/webrender/?rev=c939a61b)" = "<none>"
+"checksum webrender 0.58.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32b55a139f9352af09e6fa14324c6eab67073bd9d10871b2d01d5e8ac141d2b1"
+"checksum webrender_api 0.58.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6bdc7f5f8a6c5a852da9d70804a35ff530ac3575b17106eff3b28a6dc95c1f"
 "checksum websocket 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9234b4e667c19995475227172446884f516ec0963380afa960d962ab9f4c0bfa"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -33,6 +33,10 @@ git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
 [dependencies.gstreamer-audio]
 git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
 
+[dependencies.gstreamer-gl]
+git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
+features = ["egl"]
+
 [dependencies.gstreamer-player]
 git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
 

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -33,10 +33,6 @@ git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
 [dependencies.gstreamer-audio]
 git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
 
-[dependencies.gstreamer-gl]
-git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
-features = ["egl"]
-
 [dependencies.gstreamer-player]
 git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
 
@@ -48,6 +44,12 @@ git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
 
 [dependencies.gstreamer-video]
 git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+gstreamer-gl = { git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gstreamer-gl = { git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", features = ["egl"] }
 
 [dependencies.ipc-channel]
 version = "0.11"

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["The Servo Project Developers"]
 [build-dependencies]
 regex = "1.0"
 zip = "0.3.1"
+lazy_static = "1.0"
 
 [dependencies]
 boxfnonce = "0.1.0"
@@ -13,44 +14,36 @@ boxfnonce = "0.1.0"
 [dependencies.byte-slice-cast]
 version = "0.2"
 
-[dependencies.glib]
-version = "0.6"
-
 [dependencies.glib-sys]
-version = "0.7"
-
-[dependencies.gobject-subclass]
-version = "0.2.1"
-
-[dependencies.gobject-sys]
-version = "0.7"
-
-[dependencies.gst-plugin]
-version = "0.3.1"
-
-[dependencies.gstreamer]
-version = "0.12"
-
-[dependencies.gstreamer-app]
-version = "0.12"
-
-[dependencies.gstreamer-audio]
-version = "0.12"
-
-[dependencies.gstreamer-player]
-version = "0.12"
+git = "https://github.com/gtk-rs/sys"
 
 [dependencies.gstreamer-sys]
-version = "0.6.1"
+git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs-sys"
+
+[dependencies.glib]
+git = "https://github.com/gtk-rs/glib"
+
+[dependencies.gstreamer]
+git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
+features = ["subclassing"]
+
+[dependencies.gstreamer-app]
+git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
+
+[dependencies.gstreamer-audio]
+git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
+
+[dependencies.gstreamer-player]
+git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
 
 [dependencies.gstreamer-sdp]
-version = "0.12"
+git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
 
 [dependencies.gstreamer-webrtc]
-version = "0.12"
+git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
 
 [dependencies.gstreamer-video]
-version = "0.12"
+git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs"
 
 [dependencies.ipc-channel]
 version = "0.11"

--- a/backends/gstreamer/src/audio_decoder.rs
+++ b/backends/gstreamer/src/audio_decoder.rs
@@ -227,7 +227,7 @@ impl AudioDecoder for GStreamerAudioDecoder {
                                         ));
                                         return gst::FlowReturn::Error;
                                     };
-                                    assert_eq!(audio_info.channels(), 1);
+
                                     let positions = if let Some(positions) = audio_info.positions()
                                     {
                                         positions

--- a/backends/gstreamer/src/audio_decoder.rs
+++ b/backends/gstreamer/src/audio_decoder.rs
@@ -160,7 +160,7 @@ impl AudioDecoder for GStreamerAudioDecoder {
 
                 deinterleave
                     .set_property("keep-positions", &true.to_value())
-                    .map_err(|e| AudioDecoderError::Backend(e.to_string()))?;
+                    .expect("deinterleave doesn't have expected 'keep-positions' property");
                 let pipeline_ = pipeline.downgrade();
                 let callbacks_ = callbacks.clone();
                 deinterleave.connect_pad_added(move |_, src_pad| {
@@ -188,7 +188,7 @@ impl AudioDecoder for GStreamerAudioDecoder {
                         )?;
                         let appsink = sink.clone().dynamic_cast::<gst_app::AppSink>().unwrap();
                         sink.set_property("sync", &false.to_value())
-                            .map_err(|e| AudioDecoderError::Backend(e.to_string()))?;
+                            .expect("appsink doesn't handle expected 'sync' property");
 
                         let callbacks_ = callbacks.clone();
                         appsink.set_callbacks(
@@ -277,9 +277,9 @@ impl AudioDecoder for GStreamerAudioDecoder {
                 let caps = audio_info
                     .to_caps()
                     .ok_or(AudioDecoderError::Backend("AudioInfo failed".to_owned()))?;
-                filter.set_property("caps", &caps.to_value()).map_err(|_| {
-                    AudioDecoderError::Backend("Setting caps property failed".to_owned())
-                })?;
+                filter
+                    .set_property("caps", &caps.to_value())
+                    .expect("capsfilter doesn't have expected 'caps' property");
 
                 let elements = &[&convert, &resample, &filter, &deinterleave];
                 pipeline

--- a/backends/gstreamer/src/audio_decoder.rs
+++ b/backends/gstreamer/src/audio_decoder.rs
@@ -194,49 +194,30 @@ impl AudioDecoder for GStreamerAudioDecoder {
                         appsink.set_callbacks(
                             gst_app::AppSinkCallbacks::new()
                                 .new_sample(move |appsink| {
-                                    let sample = match appsink.pull_sample() {
-                                        None => {
-                                            return gst::FlowReturn::Eos;
-                                        }
-                                        Some(sample) => sample,
-                                    };
-
-                                    let buffer = if let Some(buffer) = sample.get_buffer() {
-                                        buffer
-                                    } else {
+                                    let sample =
+                                        appsink.pull_sample().ok_or(gst::FlowError::Eos)?;
+                                    let buffer = sample.get_buffer().ok_or_else(|| {
                                         callbacks_.error(AudioDecoderError::InvalidSample);
-                                        return gst::FlowReturn::Error;
-                                    };
+                                        gst::FlowError::Error
+                                    })?;
 
-                                    let caps = if let Some(caps) = sample.get_caps() {
-                                        caps
-                                    } else {
-                                        callbacks_.error(AudioDecoderError::Backend(
-                                            "Could not get caps from sample".to_owned(),
-                                        ));
-                                        return gst::FlowReturn::Error;
-                                    };
-
-                                    let audio_info = if let Some(audio_info) =
-                                        gst_audio::AudioInfo::from_caps(&caps)
-                                    {
-                                        audio_info
-                                    } else {
+                                    let audio_info = sample
+                                        .get_caps()
+                                        .and_then(|caps| {
+                                            gst_audio::AudioInfo::from_caps(caps.as_ref())
+                                        })
+                                        .ok_or_else(|| {
+                                            callbacks_.error(AudioDecoderError::Backend(
+                                                "Could not get caps from sample".to_owned(),
+                                            ));
+                                            gst::FlowError::Error
+                                        })?;
+                                    let positions = audio_info.positions().ok_or_else(|| {
                                         callbacks_.error(AudioDecoderError::Backend(
                                             "AudioInfo failed".to_owned(),
                                         ));
-                                        return gst::FlowReturn::Error;
-                                    };
-
-                                    let positions = if let Some(positions) = audio_info.positions()
-                                    {
-                                        positions
-                                    } else {
-                                        callbacks_.error(AudioDecoderError::Backend(
-                                            "AudioInfo failed".to_owned(),
-                                        ));
-                                        return gst::FlowReturn::Error;
-                                    };
+                                        gst::FlowError::Error
+                                    })?;
 
                                     for position in positions.iter() {
                                         let buffer = buffer.clone();
@@ -246,14 +227,14 @@ impl AudioDecoder for GStreamerAudioDecoder {
                                             map
                                         } else {
                                             callbacks_.error(AudioDecoderError::BufferReadFailed);
-                                            return gst::FlowReturn::Error;
+                                            return Err(gst::FlowError::Error);
                                         };
                                         let progress = Box::new(GStreamerAudioDecoderProgress(map));
                                         let channel = position.to_mask() as u32;
                                         callbacks_.progress(progress, channel);
                                     }
 
-                                    gst::FlowReturn::Ok
+                                    Ok(gst::FlowSuccess::Ok)
                                 })
                                 .build(),
                         );
@@ -276,13 +257,9 @@ impl AudioDecoder for GStreamerAudioDecoder {
                                 .ok_or(AudioDecoderError::Backend(
                                     "Could not get static pad sink".to_owned(),
                                 ))?;
-                        src_pad
-                            .link(&sink_pad)
-                            .into_result()
-                            .map(|_| ())
-                            .map_err(|_| {
-                                AudioDecoderError::Backend("Sink pad link failed".to_owned())
-                            })
+                        src_pad.link(&sink_pad).map(|_| ()).map_err(|_| {
+                            AudioDecoderError::Backend("Sink pad link failed".to_owned())
+                        })
                     };
 
                     if let Err(e) = insert_sink() {
@@ -323,7 +300,6 @@ impl AudioDecoder for GStreamerAudioDecoder {
                     ))?;
                 src_pad
                     .link(&sink_pad)
-                    .into_result()
                     .map(|_| ())
                     .map_err(|_| AudioDecoderError::Backend("Sink pad link failed".to_owned()))
             };
@@ -368,11 +344,7 @@ impl AudioDecoder for GStreamerAudioDecoder {
             gst::BusSyncReply::Drop
         });
 
-        if pipeline
-            .set_state(gst::State::Playing)
-            .into_result()
-            .is_err()
-        {
+        if pipeline.set_state(gst::State::Playing).is_err() {
             callbacks.error(AudioDecoderError::StateChangeFailed);
             return;
         }

--- a/backends/gstreamer/src/audio_sink.rs
+++ b/backends/gstreamer/src/audio_sink.rs
@@ -116,7 +116,6 @@ impl AudioSink for GStreamerAudioSink {
     fn play(&self) -> Result<(), AudioSinkError> {
         self.pipeline
             .set_state(gst::State::Playing)
-            .into_result()
             .map(|_| ())
             .map_err(|_| AudioSinkError::StateChangeFailed)
     }
@@ -124,7 +123,6 @@ impl AudioSink for GStreamerAudioSink {
     fn stop(&self) -> Result<(), AudioSinkError> {
         self.pipeline
             .set_state(gst::State::Paused)
-            .into_result()
             .map(|_| ())
             .map_err(|_| AudioSinkError::StateChangeFailed)
     }
@@ -184,7 +182,6 @@ impl AudioSink for GStreamerAudioSink {
 
         self.appsrc
             .push_buffer(buffer)
-            .into_result()
             .map(|_| ())
             .map_err(|_| AudioSinkError::BufferPushFailed)
     }

--- a/backends/gstreamer/src/lib.rs
+++ b/backends/gstreamer/src/lib.rs
@@ -1,20 +1,19 @@
+#![feature(nll)]
+
 extern crate boxfnonce;
 extern crate byte_slice_cast;
 
+extern crate glib_sys as glib_ffi;
+extern crate gstreamer_sys as gst_ffi;
+
 #[macro_use]
 extern crate glib;
-extern crate glib_sys as glib_ffi;
-extern crate gobject_sys as gobject_ffi;
-#[macro_use]
-extern crate gobject_subclass;
-extern crate gst_plugin;
 #[macro_use]
 extern crate gstreamer as gst;
 extern crate gstreamer_app as gst_app;
 extern crate gstreamer_audio as gst_audio;
 extern crate gstreamer_player as gst_player;
 extern crate gstreamer_sdp as gst_sdp;
-extern crate gstreamer_sys as gst_ffi;
 extern crate gstreamer_video as gst_video;
 extern crate gstreamer_webrtc as gst_webrtc;
 extern crate ipc_channel;
@@ -89,11 +88,50 @@ impl GStreamerBackend {
         media_stream::MediaSink::new()
     }
 
-    pub fn create_audioinput_stream(set: MediaTrackConstraintSet) -> Option<media_stream::GStreamerMediaStream> {
+    pub fn create_audioinput_stream(
+        set: MediaTrackConstraintSet,
+    ) -> Option<media_stream::GStreamerMediaStream> {
         media_capture::create_audioinput_stream(set)
     }
 
-    pub fn create_videoinput_stream(set: MediaTrackConstraintSet) -> Option<media_stream::GStreamerMediaStream> {
+    pub fn create_videoinput_stream(
+        set: MediaTrackConstraintSet,
+    ) -> Option<media_stream::GStreamerMediaStream> {
         media_capture::create_videoinput_stream(set)
+    }
+}
+
+pub fn set_element_flags<T: glib::IsA<gst::Object> + glib::IsA<gst::Element>>(
+    element: &T,
+    flags: gst::ElementFlags,
+) {
+    unsafe {
+        use glib::translate::ToGlib;
+        use gst_ffi;
+
+        let ptr: *mut gst_ffi::GstObject = element.as_ptr() as *mut _;
+        let _guard = MutexGuard::lock(&(*ptr).lock);
+        (*ptr).flags |= flags.to_glib();
+    }
+}
+
+struct MutexGuard<'a>(&'a glib_ffi::GMutex);
+
+impl<'a> MutexGuard<'a> {
+    pub fn lock(mutex: &'a glib_ffi::GMutex) -> Self {
+        use glib::translate::mut_override;
+        unsafe {
+            glib_ffi::g_mutex_lock(mut_override(mutex));
+        }
+        MutexGuard(mutex)
+    }
+}
+
+impl<'a> Drop for MutexGuard<'a> {
+    fn drop(&mut self) {
+        use glib::translate::mut_override;
+        unsafe {
+            glib_ffi::g_mutex_unlock(mut_override(self.0));
+        }
     }
 }

--- a/backends/gstreamer/src/lib.rs
+++ b/backends/gstreamer/src/lib.rs
@@ -12,6 +12,7 @@ extern crate glib;
 extern crate gstreamer as gst;
 extern crate gstreamer_app as gst_app;
 extern crate gstreamer_audio as gst_audio;
+extern crate gstreamer_gl as gst_gl;
 extern crate gstreamer_player as gst_player;
 extern crate gstreamer_sdp as gst_sdp;
 extern crate gstreamer_video as gst_video;

--- a/backends/gstreamer/src/media_stream.rs
+++ b/backends/gstreamer/src/media_stream.rs
@@ -75,7 +75,9 @@ impl GStreamerMediaStream {
     pub fn create_video() -> GStreamerMediaStream {
         let videotestsrc = gst::ElementFactory::make("videotestsrc", None).unwrap();
         videotestsrc.set_property_from_str("pattern", "ball");
-        videotestsrc.set_property("is-live", &true).unwrap();
+        videotestsrc
+            .set_property("is-live", &true)
+            .expect("videotestsrc doesn't have expected 'is-live' property");
 
         Self::create_video_from(videotestsrc)
     }
@@ -85,7 +87,9 @@ impl GStreamerMediaStream {
         let queue = gst::ElementFactory::make("queue", None).unwrap();
         let vp8enc = gst::ElementFactory::make("vp8enc", None).unwrap();
 
-        vp8enc.set_property("deadline", &1i64).unwrap();
+        vp8enc
+            .set_property("deadline", &1i64)
+            .expect("vp8enc doesn't have expected 'deadline' property");
 
         let rtpvp8pay = gst::ElementFactory::make("rtpvp8pay", None).unwrap();
         let queue2 = gst::ElementFactory::make("queue", None).unwrap();
@@ -100,7 +104,9 @@ impl GStreamerMediaStream {
     pub fn create_audio() -> GStreamerMediaStream {
         let audiotestsrc = gst::ElementFactory::make("audiotestsrc", None).unwrap();
         audiotestsrc.set_property_from_str("wave", "red-noise");
-        audiotestsrc.set_property("is-live", &true).unwrap();
+        audiotestsrc
+            .set_property("is-live", &true)
+            .expect("audiotestsrc doesn't have expected 'is-live' property");
 
         Self::create_audio_from(audiotestsrc)
     }

--- a/backends/gstreamer/src/player.rs
+++ b/backends/gstreamer/src/player.rs
@@ -842,19 +842,23 @@ impl Player for GStreamerPlayer {
     fn set_gl_params(&self, gl_context: GlContext, gl_display: usize) -> Result<(), ()> {
         let (display, context) = match gl_context {
             GlContext::Egl(ctxt) => {
-                let display = unsafe { gst_gl::GLDisplayEGL::new_with_egl_display(gl_display) };
+                if cfg!(target_os = "linux") {
+                    let display = unsafe { gst_gl::GLDisplayEGL::new_with_egl_display(gl_display) };
 
-                if let Some(display) = display {
-                    let context = unsafe {
-                        gst_gl::GLContext::new_wrapped(
-                            &display,
-                            ctxt,
-                            gst_gl::GLPlatform::EGL,
-                            gst_gl::GLAPI::ANY,
-                        )
-                    };
+                    if let Some(display) = display {
+                        let context = unsafe {
+                            gst_gl::GLContext::new_wrapped(
+                                &display,
+                                ctxt,
+                                gst_gl::GLPlatform::EGL,
+                                gst_gl::GLAPI::ANY,
+                            )
+                        };
 
-                    (Some(display.upcast::<gst_gl::GLDisplay>()), context)
+                        (Some(display.upcast::<gst_gl::GLDisplay>()), context)
+                    } else {
+                        (None, None)
+                    }
                 } else {
                     (None, None)
                 }

--- a/backends/gstreamer/src/player.rs
+++ b/backends/gstreamer/src/player.rs
@@ -346,7 +346,7 @@ impl GStreamerPlayer {
 
         pipeline
             .set_property("video-sink", &video_sink.to_value())
-            .map_err(|e| PlayerError::Backend(e.to_string()))?;
+            .expect("playbin doesn't have expected 'video-sink' property");
 
         let video_sink = video_sink.dynamic_cast::<gst_app::AppSink>().unwrap();
         video_sink.set_caps(&gst::Caps::new_simple(
@@ -390,7 +390,7 @@ impl GStreamerPlayer {
         // faster playback of already-downloaded chunks.
         let flags = pipeline
             .get_property("flags")
-            .map_err(|e| PlayerError::Backend(e.to_string()))?;
+            .expect("playbin doesn't have expected 'flags' property");
         let flags_class = match glib::FlagsClass::new(flags.type_()) {
             Some(flags) => flags,
             None => {
@@ -417,12 +417,12 @@ impl GStreamerPlayer {
         };
         pipeline
             .set_property("flags", &flags)
-            .map_err(|e| PlayerError::Backend(e.to_string()))?;
+            .expect("playbin doesn't have expected 'flags' property");
 
         // Set max size for the player buffer.
         pipeline
             .set_property("buffer-size", &MAX_BUFFER_SIZE)
-            .map_err(|e| PlayerError::Backend(e.to_string()))?;
+            .expect("playbin doesn't have expected 'buffer-size' property");
 
         // Set player position interval update to 0.5 seconds.
         let mut config = player.get_config();
@@ -442,7 +442,7 @@ impl GStreamerPlayer {
         // https://github.com/servo/servo/issues/22010#issuecomment-432599657
         player
             .set_property("uri", &glib::Value::from("servosrc://"))
-            .map_err(|e| PlayerError::Backend(e.to_string()))?;
+            .expect("playbin doesn't have expected 'uri' property");
 
         *self.inner.borrow_mut() = Some(Arc::new(Mutex::new(PlayerInner {
             player,

--- a/backends/gstreamer/src/webrtc.rs
+++ b/backends/gstreamer/src/webrtc.rs
@@ -106,10 +106,7 @@ impl WebRtcControllerBackend for GStreamerWebRtcController {
     fn quit(&mut self) {
         self.signaller.close();
 
-        self.pipeline
-            .set_state(gst::State::Null)
-            .into_result()
-            .unwrap();
+        self.pipeline.set_state(gst::State::Null).unwrap();
 
         //main_loop.quit();
     }
@@ -168,10 +165,7 @@ impl GStreamerWebRtcController {
                 None
             })
             .unwrap();
-        self.pipeline
-            .set_state(gst::State::Playing)
-            .into_result()
-            .unwrap();
+        self.pipeline.set_state(gst::State::Playing).unwrap();
     }
 
     fn start_pipeline(&mut self) {
@@ -291,7 +285,7 @@ fn handle_media_stream(
     conv.sync_state_with_parent()?;
 
     let qpad = q.get_static_pad("sink").unwrap();
-    pad.link(&qpad).into_result()?;
+    pad.link(&qpad)?;
 
     let stream = Box::new(GStreamerMediaStream::create_stream_with_pipeline(
         media_type,

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 servo-media = { path = "../servo-media" }
-webrender = { git = "https://github.com/servo/webrender/", rev = "c939a61b" }
+webrender = "0.58.0"
 websocket = "0.20"
 ipc-channel = "0.11"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,7 +20,7 @@ ipc-channel = "0.11"
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 winit = "0.18"
-glutin = "0.19.0"
+glutin = { git = "https://github.com/tomaka/glutin" }
 
 [[bin]]
 name = "audio_decoder"

--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -113,13 +113,13 @@ impl ui::Example for App {
         }
 
         let frame = self.frame_queue.lock().unwrap().get().unwrap();
-        let width = frame.get_width() as u32;
-        let height = frame.get_height() as u32;
+        let width = frame.get_width();
+        let height = frame.get_height();
 
         if self.image_key.is_some() {
             if let Some(old_frame) = self.frame_queue.lock().unwrap().prev() {
-                let old_width = old_frame.get_width() as u32;
-                let old_height = old_frame.get_height() as u32;
+                let old_width = old_frame.get_width();
+                let old_height = old_frame.get_height();
                 if (width != old_width) || (height != old_height) {
                     txn.delete_image(self.image_key.unwrap());
                     self.image_key = None;
@@ -144,7 +144,7 @@ impl ui::Example for App {
                 self.image_key.clone().unwrap(),
                 image_descriptor,
                 image_data,
-                None,
+                &DirtyRect::All,
             );
         }
 
@@ -155,9 +155,10 @@ impl ui::Example for App {
             None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
-            Vec::new(),
-            GlyphRasterSpace::Screen,
+            &[],
+            RasterSpace::Screen,
         );
+
         let image_size = LayoutSize::new(width as f32, height as f32);
         let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_image(
@@ -167,6 +168,7 @@ impl ui::Example for App {
             ImageRendering::Auto,
             AlphaType::PremultipliedAlpha,
             self.image_key.clone().unwrap(),
+            ColorF::WHITE,
         );
         builder.pop_stacking_context();
     }

--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -89,6 +89,7 @@ impl FrameQueue {
 struct App {
     frame_queue: Mutex<FrameQueue>,
     image_key: Option<ImageKey>,
+    use_gl: bool,
 }
 
 impl App {
@@ -96,6 +97,7 @@ impl App {
         Self {
             frame_queue: Mutex::new(FrameQueue::new()),
             image_key: None,
+            use_gl: false,
         }
     }
 }
@@ -192,6 +194,10 @@ impl ui::Example for App {
     }
 
     fn draw_custom(&self, _gl: &gl::Gl) {}
+
+    fn use_gl(&mut self, use_gl: bool) {
+        self.use_gl = use_gl;
+    }
 }
 
 impl FrameRenderer for App {
@@ -208,13 +214,21 @@ fn main() {
 #[cfg(not(target_os = "android"))]
 fn main() {
     let args: Vec<_> = env::args().collect();
-    let filename: &str = if args.len() == 2 {
-        args[1].as_ref()
+    let (use_gl, filename) = if args.len() == 2 {
+        let fname: &str = args[1].as_ref();
+        (false, fname)
+    } else if args.len() == 3 {
+        if args[1] == "--gl" {
+            let fname: &str = args[2].as_ref();
+            (true, fname)
+        } else {
+            panic!("Usage: cargo run --bin player [--gl] <file_path>")
+        }
     } else {
-        panic!("Usage: cargo run --bin player <file_path>")
+        panic!("Usage: cargo run --bin player [--gl] <file_path>")
     };
 
     let path = Path::new(filename);
     let app = Arc::new(Mutex::new(App::new()));
-    ui::main_wrapper(app, &path, None);
+    ui::main_wrapper(app, &path, use_gl, None);
 }

--- a/examples/player/player_wrapper.rs
+++ b/examples/player/player_wrapper.rs
@@ -16,12 +16,14 @@ use std::thread::Builder;
 pub struct PlayerWrapper {
     player: Arc<Mutex<Box<Player>>>,
     shutdown: Arc<AtomicBool>,
+    use_gl: bool,
 }
 
 impl PlayerWrapper {
-    pub fn new(path: &Path) -> Self {
+    pub fn new(path: &Path, use_gl: bool) -> Self {
         let servo_media = ServoMedia::get().unwrap();
         let player = Arc::new(Mutex::new(servo_media.create_player()));
+        // TODO: verify if gl is possible
         let file = File::open(&path).unwrap();
         let metadata = file.metadata().unwrap();
         player
@@ -103,12 +105,20 @@ impl PlayerWrapper {
 
         player.lock().unwrap().play().unwrap();
 
-        PlayerWrapper { player, shutdown }
+        PlayerWrapper {
+            player,
+            shutdown,
+            use_gl,
+        }
     }
 
     pub fn shutdown(&self) {
         self.player.lock().unwrap().stop().unwrap();
         self.shutdown.store(true, Ordering::Relaxed);
+    }
+
+    pub fn use_gl(&self) -> bool {
+        self.use_gl
     }
 
     pub fn register_frame_renderer(&self, renderer: Arc<Mutex<FrameRenderer>>) {

--- a/examples/player/player_wrapper.rs
+++ b/examples/player/player_wrapper.rs
@@ -14,14 +14,14 @@ use std::sync::{Arc, Mutex};
 use std::thread::Builder;
 
 pub struct PlayerWrapper {
-    player: Arc<Mutex<Box<Player>>>,
+    player: Arc<Mutex<Box<dyn Player>>>,
     shutdown: Arc<AtomicBool>,
     use_gl: bool,
 }
 
 impl PlayerWrapper {
     fn set_gl_params(
-        player: &Arc<Mutex<Box<Player>>>,
+        player: &Arc<Mutex<Box<dyn Player>>>,
         window: &glutin::GlWindow,
     ) -> Result<(), ()> {
         use glutin::os::unix::RawHandle;

--- a/examples/player/player_wrapper.rs
+++ b/examples/player/player_wrapper.rs
@@ -20,6 +20,7 @@ pub struct PlayerWrapper {
 }
 
 impl PlayerWrapper {
+    #[cfg(target_os = "linux")]
     fn set_gl_params(
         player: &Arc<Mutex<Box<dyn Player>>>,
         window: &glutin::GlWindow,
@@ -41,6 +42,11 @@ impl PlayerWrapper {
             }
             RawHandle::Glx(_) => Err(()),
         }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn set_gl_params(_: &Arc<Mutex<Box<dyn Player>>>, _: &glutin::GlWindow) -> Result<(), ()> {
+        Err(())
     }
 
     pub fn new(path: &Path, window: Option<&glutin::GlWindow>) -> Self {

--- a/examples/player/ui.rs
+++ b/examples/player/ui.rs
@@ -57,6 +57,7 @@ pub trait HandyDandyRectBuilder {
     fn to(&self, x2: i32, y2: i32) -> LayoutRect;
     fn by(&self, w: i32, h: i32) -> LayoutRect;
 }
+
 // Allows doing `(x, y).to(x2, y2)` or `(x, y).by(width, height)` with i32
 // values to build a f32 LayoutRect
 impl HandyDandyRectBuilder for (i32, i32) {
@@ -102,11 +103,14 @@ pub trait Example {
         (None, None)
     }
     fn draw_custom(&self, _gl: &gl::Gl) {}
+
+    fn use_gl(&mut self, _use_gl: bool) {}
 }
 
 pub fn main_wrapper<E: Example + FrameRenderer>(
     example: Arc<Mutex<E>>,
     path: &Path,
+    use_gl: bool,
     options: Option<webrender::RendererOptions>,
 ) {
     env_logger::init();
@@ -193,7 +197,8 @@ pub fn main_wrapper<E: Example + FrameRenderer>(
     txn.generate_frame();
     api.send_transaction(document_id, txn);
 
-    let player_wrapper = PlayerWrapper::new(path);
+    let player_wrapper = PlayerWrapper::new(path, use_gl);
+    example.lock().unwrap().use_gl(player_wrapper.use_gl());
     player_wrapper.register_frame_renderer(example.clone());
 
     println!("Entering event loop");

--- a/examples/player/ui.rs
+++ b/examples/player/ui.rs
@@ -172,6 +172,11 @@ pub fn main_wrapper<E: Example + FrameRenderer>(
     let api = sender.create_api();
     let document_id = api.add_document(framebuffer_size, 0);
 
+    let gl_win = if use_gl { Some(&window) } else { None };
+    let player_wrapper = PlayerWrapper::new(path, gl_win);
+    example.lock().unwrap().use_gl(player_wrapper.use_gl());
+    player_wrapper.register_frame_renderer(example.clone());
+
     let (external, output) = example.lock().unwrap().get_image_handlers(&*gl);
 
     if let Some(output_image_handler) = output {
@@ -196,10 +201,6 @@ pub fn main_wrapper<E: Example + FrameRenderer>(
     txn.set_root_pipeline(pipeline_id);
     txn.generate_frame();
     api.send_transaction(document_id, txn);
-
-    let player_wrapper = PlayerWrapper::new(path, use_gl);
-    example.lock().unwrap().use_gl(player_wrapper.use_gl());
-    player_wrapper.register_frame_renderer(example.clone());
 
     println!("Entering event loop");
     events_loop.run_forever(|global_event| {

--- a/player/src/frame.rs
+++ b/player/src/frame.rs
@@ -1,19 +1,32 @@
 use std::sync::Arc;
 
 #[derive(Clone)]
+pub enum FrameData {
+    Raw(Arc<Vec<u8>>),
+}
+
+pub trait Buffer: Send + Sync {
+    fn to_vec(&self) -> Result<FrameData, ()>;
+}
+
+#[derive(Clone)]
 pub struct Frame {
     width: i32,
     height: i32,
-    data: Arc<Vec<u8>>,
+    data: FrameData,
+    buffer: Arc<Buffer>,
 }
 
 impl Frame {
-    pub fn new(width: i32, height: i32, data: Arc<Vec<u8>>) -> Frame {
-        Frame {
+    pub fn new(width: i32, height: i32, buffer: Arc<Buffer>) -> Result<Self, ()> {
+        let data = buffer.to_vec()?;
+
+        Ok(Frame {
             width,
             height,
             data,
-        }
+            buffer,
+        })
     }
 
     pub fn get_width(&self) -> i32 {
@@ -25,7 +38,9 @@ impl Frame {
     }
 
     pub fn get_data(&self) -> Arc<Vec<u8>> {
-        self.data.clone()
+        match self.data {
+            FrameData::Raw(ref data) => data.clone(),
+        }
     }
 }
 

--- a/player/src/frame.rs
+++ b/player/src/frame.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub enum FrameData {
     Raw(Arc<Vec<u8>>),
+    Texture(u32),
 }
 
 pub trait Buffer: Send + Sync {
@@ -40,6 +41,14 @@ impl Frame {
     pub fn get_data(&self) -> Arc<Vec<u8>> {
         match self.data {
             FrameData::Raw(ref data) => data.clone(),
+            _ => unreachable!("invalid raw data request for texture frame"),
+        }
+    }
+
+    pub fn get_texture_id(&self) -> u32 {
+        match self.data {
+            FrameData::Texture(data) => data,
+            _ => unreachable!("invalid texture id request for raw data frame"),
         }
     }
 }

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -64,6 +64,15 @@ pub enum StreamType {
     RandomAccess,
 }
 
+pub enum GlContext {
+    // the EGL platform used primarily with the X11, wayland and
+    // android window systems as well as on embedded Linux
+    Egl(usize),
+    // the GLX platform used primarily with the X11 window system
+    Glx(usize),
+    Unknown,
+}
+
 pub trait Player: Send {
     fn register_event_handler(&self, sender: IpcSender<PlayerEvent>);
     fn register_frame_renderer(&self, renderer: Arc<Mutex<frame::FrameRenderer>>);
@@ -80,6 +89,7 @@ pub trait Player: Send {
     fn end_of_stream(&self) -> Result<(), PlayerError>;
     /// Get the list of time ranges in seconds that have been buffered.
     fn buffered(&self) -> Result<Vec<Range<f64>>, PlayerError>;
+    fn set_gl_params(&self, gl_context: GlContext, gl_display: usize) -> Result<(), ()>;
 }
 
 pub struct DummyPlayer {}
@@ -126,6 +136,9 @@ impl Player for DummyPlayer {
     }
     fn buffered(&self) -> Result<Vec<Range<f64>>, PlayerError> {
         Ok(vec![])
+    }
+    fn set_gl_params(&self, _: GlContext, _: usize) -> Result<(), ()> {
+        Err(())
     }
 }
 


### PR DESCRIPTION
This PR goes above PR https://github.com/servo/media/pull/196

It needs to update the CI GStreamer setup, because it requires  a new version of glib and gstreamer-gl library.

It contains

* Port to webrender 0.58 
* Port to gstreamer git head version (0.13.0) -- this implied a complete rewrite of servosrc
* Add a new trait in Frame to hold a reference to the backend's buffer
* Update glutin version tu current git head
* Add a method to set the GL parameters in the backend's player
* Use glsinkbin in gstreamer player in GL parameters are negotiated
* A lot of changes in example player to render gl textures is --gl argument is passed

Fixes: https://github.com/servo/media/issues/166