### PR TITLE
make the build of examples optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,12 @@ members = [
   "servo-media-derive",
   "webrtc"
 ]
+default-members = [
+  "audio",
+  "backends/gstreamer",
+  "player",
+  "servo-media",
+  "servo-media-derive",
+  "webrtc"
+]
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ For macOS, Windows, and Linux, simply run:
 ```bash
 cargo build
 ```
+To also build the xamples:
+```bash
+cargo build --all
+```
 For Android, run:
 ```bash
 PKG_CONFIG_ALLOW_CROSS=1 cargo build --target=arm-linux-androideabi


### PR DESCRIPTION
The examples inside of the project have more dependencies than the project itself. This creates the issue that by default, if someone tries to build without any of these dependencies, the build will fail.

A better approach would be to make the build of examples optional, because they are not necessary for the library to function. They are just there for pedagogic purposes. Also, not building the examples all the time will speed up build time in downstream projects. 

With this change if you run the following command no examples will be built.

> cargo build 

If you run the following command all examples will be built.

> cargo build --all