### PR TITLE
Clean up and misc fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-media 0.1.0",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.57.2 (git+https://github.com/servo/webrender/)",
+ "webrender 0.57.2 (git+https://github.com/servo/webrender/?rev=c939a61b)",
  "websocket 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2211,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.57.2"
-source = "git+https://github.com/servo/webrender/#c939a61b83bcc9dc10742977704793e9a85b3858"
+source = "git+https://github.com/servo/webrender/?rev=c939a61b#c939a61b83bcc9dc10742977704793e9a85b3858"
 dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2234,13 +2234,13 @@ dependencies = [
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_api 0.57.2 (git+https://github.com/servo/webrender/)",
+ "webrender_api 0.57.2 (git+https://github.com/servo/webrender/?rev=c939a61b)",
 ]
 
 [[package]]
 name = "webrender_api"
 version = "0.57.2"
-source = "git+https://github.com/servo/webrender/#c939a61b83bcc9dc10742977704793e9a85b3858"
+source = "git+https://github.com/servo/webrender/?rev=c939a61b#c939a61b83bcc9dc10742977704793e9a85b3858"
 dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2617,8 +2617,8 @@ dependencies = [
 "checksum wayland-protocols 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f6cebb98963f028d397e9bad2acf9d3b2f6b76fae65aea191edd9e7c0df88c"
 "checksum wayland-scanner 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f1927ee62e4e149c010dc9eca8ca47e238416cd6f45f688eb9f8a8e9c3794c30"
 "checksum wayland-sys 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ca41ed78a12256f81df6f53fcbe4503213ba442e02cdad3c9c888a64a668eaf4"
-"checksum webrender 0.57.2 (git+https://github.com/servo/webrender/)" = "<none>"
-"checksum webrender_api 0.57.2 (git+https://github.com/servo/webrender/)" = "<none>"
+"checksum webrender 0.57.2 (git+https://github.com/servo/webrender/?rev=c939a61b)" = "<none>"
+"checksum webrender_api 0.57.2 (git+https://github.com/servo/webrender/?rev=c939a61b)" = "<none>"
 "checksum websocket 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9234b4e667c19995475227172446884f516ec0963380afa960d962ab9f4c0bfa"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"

--- a/backends/gstreamer/src/lib.rs
+++ b/backends/gstreamer/src/lib.rs
@@ -8,6 +8,7 @@ extern crate gobject_sys as gobject_ffi;
 #[macro_use]
 extern crate gobject_subclass;
 extern crate gst_plugin;
+#[macro_use]
 extern crate gstreamer as gst;
 extern crate gstreamer_app as gst_app;
 extern crate gstreamer_audio as gst_audio;

--- a/backends/gstreamer/src/media_stream.rs
+++ b/backends/gstreamer/src/media_stream.rs
@@ -1,6 +1,7 @@
-use glib::ObjectExt;
-use gst::{self, BinExt, BinExtManual, ElementExt, GObjectExtManualGst};
-use servo_media_webrtc::{MediaStream, MediaOutput};
+use glib::prelude::*;
+use gst;
+use gst::prelude::*;
+use servo_media_webrtc::{MediaOutput, MediaStream};
 use std::any::Any;
 
 lazy_static! {
@@ -132,7 +133,7 @@ impl GStreamerMediaStream {
     pub fn create_stream_with_pipeline(
         type_: StreamType,
         elements: Vec<gst::Element>,
-        pipeline: gst::Pipeline
+        pipeline: gst::Pipeline,
     ) -> GStreamerMediaStream {
         GStreamerMediaStream {
             type_,
@@ -148,21 +149,22 @@ pub struct MediaSink {
 
 impl MediaSink {
     pub fn new() -> Self {
-        MediaSink {
-            streams: vec![],
-        }
+        MediaSink { streams: vec![] }
     }
 }
 
 impl MediaOutput for MediaSink {
     fn add_stream(&mut self, stream: Box<MediaStream>) {
         {
-            let stream = stream.as_any().downcast_ref::<GStreamerMediaStream>().unwrap();
+            let stream = stream
+                .as_any()
+                .downcast_ref::<GStreamerMediaStream>()
+                .unwrap();
             let last_element = stream.elements.last();
             let last_element = last_element.as_ref().unwrap();
             let sink = match stream.type_ {
                 StreamType::Audio => "autoaudiosink",
-                StreamType::Video =>"autovideosink",
+                StreamType::Video => "autovideosink",
             };
             let sink = gst::ElementFactory::make(sink, None).unwrap();
             stream.pipeline.as_ref().unwrap().add(&sink).unwrap();

--- a/backends/gstreamer/src/webrtc.rs
+++ b/backends/gstreamer/src/webrtc.rs
@@ -1,8 +1,10 @@
 use boxfnonce::SendBoxFnOnce;
-use glib::{self, ObjectExt};
-use gst::{self, BinExt, BinExtManual, ElementExt, GObjectExtManualGst, PadDirection, PadExt};
+use glib;
+use glib::prelude::*;
+use gst;
+use gst::prelude::*;
 use gst_sdp;
-use gst_webrtc::{self, WebRTCSDPType};
+use gst_webrtc;
 use media_stream::{GStreamerMediaStream, StreamType};
 use servo_media_webrtc::thread::InternalEvent;
 use servo_media_webrtc::WebRtcController as WebRtcThread;
@@ -13,7 +15,6 @@ use std::sync::{Arc, Mutex};
 // TODO:
 // - add a proper error enum
 // - figure out purpose of glib loop
-
 
 pub struct GStreamerWebRtcController {
     webrtc: Option<gst::Element>,
@@ -40,14 +41,11 @@ impl WebRtcControllerBackend for GStreamerWebRtcController {
     }
 
     fn set_remote_description(&mut self, desc: SessionDescription, cb: SendBoxFnOnce<'static, ()>) {
-
         self.set_description(desc, false, cb);
     }
 
     fn set_local_description(&mut self, desc: SessionDescription, cb: SendBoxFnOnce<'static, ()>) {
-
         self.set_description(desc, true, cb);
-
     }
 
     fn create_offer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>) {
@@ -124,10 +122,10 @@ impl GStreamerWebRtcController {
         cb: SendBoxFnOnce<'static, ()>,
     ) {
         let ty = match desc.type_ {
-            SdpType::Answer => WebRTCSDPType::Answer,
-            SdpType::Offer => WebRTCSDPType::Offer,
-            SdpType::Pranswer => WebRTCSDPType::Pranswer,
-            SdpType::Rollback => WebRTCSDPType::Rollback,
+            SdpType::Answer => gst_webrtc::WebRTCSDPType::Answer,
+            SdpType::Offer => gst_webrtc::WebRTCSDPType::Offer,
+            SdpType::Pranswer => gst_webrtc::WebRTCSDPType::Pranswer,
+            SdpType::Rollback => gst_webrtc::WebRTCSDPType::Rollback,
         };
 
         let kind = if local {
@@ -241,10 +239,10 @@ fn on_offer_or_answer_created(
         .expect("Invalid argument");
 
     let type_ = match reply.get_type() {
-        WebRTCSDPType::Answer => SdpType::Answer,
-        WebRTCSDPType::Offer => SdpType::Offer,
-        WebRTCSDPType::Pranswer => SdpType::Pranswer,
-        WebRTCSDPType::Rollback => SdpType::Rollback,
+        gst_webrtc::WebRTCSDPType::Answer => SdpType::Answer,
+        gst_webrtc::WebRTCSDPType::Offer => SdpType::Offer,
+        gst_webrtc::WebRTCSDPType::Pranswer => SdpType::Pranswer,
+        gst_webrtc::WebRTCSDPType::Rollback => SdpType::Rollback,
         _ => panic!("unknown sdp response"),
     };
 
@@ -297,9 +295,12 @@ fn handle_media_stream(
     let stream = Box::new(GStreamerMediaStream::create_stream_with_pipeline(
         media_type,
         elements,
-        pipe.clone()
+        pipe.clone(),
     ));
-    thread.lock().unwrap().internal_event(InternalEvent::OnAddStream(stream));
+    thread
+        .lock()
+        .unwrap()
+        .internal_event(InternalEvent::OnAddStream(stream));
 
     Ok(())
 }
@@ -364,7 +365,7 @@ fn process_new_stream(
     thread: Arc<Mutex<WebRtcThread>>,
 ) -> Option<glib::Value> {
     let pad = values[1].get::<gst::Pad>().expect("not a pad??");
-    if pad.get_direction() != PadDirection::Src {
+    if pad.get_direction() != gst::PadDirection::Src {
         // Ignore outgoing pad notifications.
         return None;
     }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 servo-media = { path = "../servo-media" }
-webrender = { git = "https://github.com/servo/webrender/" }
+webrender = { git = "https://github.com/servo/webrender/", rev = "c939a61b" }
 websocket = "0.20"
 ipc-channel = "0.11"
 

--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -129,7 +129,7 @@ impl ui::Example for App {
 
         let image_descriptor =
             ImageDescriptor::new(width, height, ImageFormat::BGRA8, false, false);
-        let image_data = ImageData::new_shared(frame.get_data().clone());
+        let image_data = ImageData::new_shared(frame.get_data());
 
         if self.image_key.is_none() {
             self.image_key = Some(api.generate_image_key());

--- a/player/src/frame.rs
+++ b/player/src/frame.rs
@@ -24,8 +24,8 @@ impl Frame {
         self.height
     }
 
-    pub fn get_data(&self) -> &Arc<Vec<u8>> {
-        &self.data
+    pub fn get_data(&self) -> Arc<Vec<u8>> {
+        self.data.clone()
     }
 }
 


### PR DESCRIPTION
This pull request is a preparation for the video frames rendering as gl textures in the player example:

* isolate the video sinks setup in a function
* add gst logging capabilities to gstreamer player backend, rather than use print macros
* specify a specific commit id to webrender, since we are using git head, but an update will break our example app
* use glib and gstreamer preludes, this is a general clean up recommended by @sdroege 
* the player example eats all the available memory since a great big image leak
* instead of keeping a vector with pushed frames from player example, add a custom queue with only three frames
* as we are using Arc'ed data, there's no need to return a reference
