### PR TITLE
Fix sink pad ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,7 @@ dependencies = [
  "gstreamer-gl 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-player 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-sdp 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gstreamer-sdp-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-video 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-webrtc 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/backends/dummy/src/lib.rs
+++ b/backends/dummy/src/lib.rs
@@ -195,7 +195,7 @@ impl WebRtcControllerBackend for DummyWebRtcController {
     fn add_ice_candidate(&mut self, _: IceCandidate) {}
     fn create_offer(&mut self, _: SendBoxFnOnce<'static, (SessionDescription,)>) {}
     fn create_answer(&mut self, _: SendBoxFnOnce<'static, (SessionDescription,)>) {}
-    fn add_stream(&mut self, _: &mut MediaStream) {}
+    fn add_stream(&mut self, _: Box<MediaStream>) {}
     fn internal_event(&mut self, _: thread::InternalEvent) {}
     fn quit(&mut self) {}
 }

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -23,6 +23,9 @@ version = "0.8"
 [dependencies.gstreamer-sys]
 version = "0.7"
 
+[dependencies.gstreamer-sdp-sys]
+version = "0.7"
+
 [dependencies.gstreamer]
 version = "0.13"
 features = ["subclassing"]

--- a/backends/gstreamer/src/media_capture.rs
+++ b/backends/gstreamer/src/media_capture.rs
@@ -128,14 +128,12 @@ impl GstMediaDevices {
             ("audio/x-raw", "Audio/Source")
         };
         let caps = into_caps(constraints, format)?;
-        println!("requesting {:?}", caps);
         let f = self.monitor.add_filter(filter, &caps);
         let devices = self.monitor.get_devices();
         if let Some(f) = f {
             let _ = self.monitor.remove_filter(f);
         }
         if let Some(d) = devices.get(0) {
-            println!("{:?}", d.get_caps());
             let element = d.create_element(None)?;
             Some(GstMediaTrack { element })
         } else {

--- a/examples/simple_webrtc.rs
+++ b/examples/simple_webrtc.rs
@@ -147,6 +147,7 @@ impl State {
         };
         webrtc.add_stream(video);
         webrtc.add_stream(audio);
+
         webrtc.configure(STUN_SERVER.into(), BundlePolicy::MaxBundle);
     }
 }

--- a/webrtc/src/lib.rs
+++ b/webrtc/src/lib.rs
@@ -93,6 +93,7 @@ pub struct IceCandidate {
 }
 
 /// https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection#RTCBundlePolicy_enum
+#[derive(Clone, Copy, Hash, Debug, PartialEq, Eq)]
 pub enum BundlePolicy {
     Balanced,
     MaxCompat,

--- a/webrtc/src/lib.rs
+++ b/webrtc/src/lib.rs
@@ -19,7 +19,7 @@ pub trait WebRtcControllerBackend: Send {
     fn add_ice_candidate(&mut self, candidate: IceCandidate);
     fn create_offer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>);
     fn create_answer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>);
-    fn add_stream(&mut self, stream: &mut MediaStream);
+    fn add_stream(&mut self, stream: Box<MediaStream>);
     fn internal_event(&mut self, event: thread::InternalEvent);
     fn quit(&mut self);
 }
@@ -47,6 +47,12 @@ pub enum SdpType {
     Offer,
     Pranswer,
     Rollback,
+}
+
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq)]
+pub enum DescriptionType {
+    Local,
+    Remote
 }
 
 impl SdpType {

--- a/webrtc/src/thread.rs
+++ b/webrtc/src/thread.rs
@@ -3,7 +3,7 @@ use std::thread;
 
 use boxfnonce::SendBoxFnOnce;
 
-use crate::{BundlePolicy, IceCandidate, MediaStream, SessionDescription};
+use crate::{BundlePolicy, DescriptionType, IceCandidate, MediaStream, SessionDescription, SdpType};
 use crate::{WebRtcBackend, WebRtcControllerBackend, WebRtcSignaller};
 
 #[derive(Clone)]
@@ -90,6 +90,7 @@ pub enum InternalEvent {
     OnNegotiationNeeded,
     OnIceCandidate(IceCandidate),
     OnAddStream(Box<MediaStream>),
+    DescriptionAdded(SendBoxFnOnce<'static, ()>, DescriptionType, SdpType),
 }
 
 pub fn handle_rtc_event(controller: &mut WebRtcControllerBackend, event: RtcThreadEvent) -> bool {
@@ -102,7 +103,7 @@ pub fn handle_rtc_event(controller: &mut WebRtcControllerBackend, event: RtcThre
         RtcThreadEvent::AddIceCandidate(candidate) => controller.add_ice_candidate(candidate),
         RtcThreadEvent::CreateOffer(cb) => controller.create_offer(cb),
         RtcThreadEvent::CreateAnswer(cb) => controller.create_answer(cb),
-        RtcThreadEvent::AddStream(mut media) => controller.add_stream(&mut *media),
+        RtcThreadEvent::AddStream(media) => controller.add_stream(media),
         RtcThreadEvent::InternalEvent(e) => controller.internal_event(e),
         RtcThreadEvent::Quit => {
             controller.quit();


### PR DESCRIPTION
Fixes #210

Based on #208

This implements a version of the fix detailed in https://github.com/servo/media/issues/210#issuecomment-467365523

Instead of unlinking/relinking, we simply keep new streams unlinked until we decide to trigger an offer, at which point we link them to new request pads. The answerer side keeps them unlinked until it gets a remote offer, at which point it also requests pads and links them to the correctly numbered request pads.

A missing piece was that the payload number also has to match, so we keep track of that too.

r? @jdm @slomo (last two commits only)