### PR TITLE
Implement can_play_type for ServoMedia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +1983,7 @@ dependencies = [
  "gstreamer-webrtc 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-media 0.1.0",
  "servo-media-audio 0.1.0",
@@ -2408,6 +2417,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicase"
 version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicase"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2873,6 +2890,7 @@ dependencies = [
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+"checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum miniz_oxide 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9ba430291c9d6cedae28bcd2d49d1c32fc57d60cd49086646c5dd5673a870eb5"
 "checksum miniz_oxide_c_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5a5b8234d6103ebfba71e29786da4608540f862de5ce980a1c94f86a40ca0d51"
 "checksum mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)" = "4fcfcb32d63961fb6f367bfd5d21e4600b92cd310f71f9dca25acae196eb1560"
@@ -2985,6 +3003,7 @@ dependencies = [
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+"checksum unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41d17211f887da8e4a70a45b9536f26fc5de166b81e2d5d80de4a17fd22553bd"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -8,7 +8,7 @@ extern crate servo_media_webrtc;
 
 use boxfnonce::SendBoxFnOnce;
 use ipc_channel::ipc::IpcSender;
-use servo_media::{Backend, BackendInit};
+use servo_media::{Backend, BackendInit, SupportsMediaType};
 use servo_media_audio::block::Chunk;
 use servo_media_audio::context::{AudioContext, AudioContextOptions};
 use servo_media_audio::decoder::{AudioDecoder, AudioDecoderCallbacks, AudioDecoderOptions};
@@ -75,6 +75,10 @@ impl Backend for DummyBackend {
 
     fn create_webrtc(&self, signaller: Box<WebRtcSignaller>) -> WebRtcController {
         WebRtcController::new::<Self>(signaller)
+    }
+
+    fn can_play_type(&self, _media_type: &str) -> SupportsMediaType {
+        SupportsMediaType::No
     }
 }
 

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -14,6 +14,7 @@ path = "lib.rs"
 
 [dependencies]
 boxfnonce = "0.1.0"
+mime = "0.3.13"
 
 [dependencies.byte-slice-cast]
 version = "0.2"

--- a/backends/gstreamer/registry_scanner.rs
+++ b/backends/gstreamer/registry_scanner.rs
@@ -1,0 +1,247 @@
+use gst;
+use std::collections::HashSet;
+
+lazy_static! {
+    // The GStreamer registry holds the metadata of the set of plugins available in the host.
+    // This scanner is used to lazily analyze the registry and to provide information about
+    // the set of supported mime types and codecs that the backend is able to deal with.
+    pub static ref GSTREAMER_REGISTRY_SCANNER: GStreamerRegistryScanner =
+        GStreamerRegistryScanner::new();
+}
+
+pub struct GStreamerRegistryScanner {
+    supported_mime_types: HashSet<&'static str>,
+    supported_codecs: HashSet<&'static str>,
+}
+
+impl GStreamerRegistryScanner {
+    fn new() -> GStreamerRegistryScanner {
+        let mut registry_scanner = GStreamerRegistryScanner {
+            supported_mime_types: HashSet::new(),
+            supported_codecs: HashSet::new(),
+        };
+        registry_scanner.initialize();
+        registry_scanner
+    }
+
+    pub fn is_container_type_supported(&self, container_type: &str) -> bool {
+        self.supported_mime_types.contains(container_type)
+    }
+
+    fn is_codec_supported(&self, codec: &str) -> bool {
+        self.supported_codecs.contains(codec)
+    }
+
+    pub fn are_all_codecs_supported(&self, codecs: &Vec<&str>) -> bool {
+        codecs.iter().all(|&codec| self.is_codec_supported(codec))
+    }
+
+    fn initialize(&mut self) {
+        let audio_decoder_factories = gst::ElementFactory::list_get_elements(
+            gst_ffi::GST_ELEMENT_FACTORY_TYPE_DECODER |
+            gst_ffi::GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO,
+            gst::Rank::Marginal,
+        );
+        let audio_parser_factories = gst::ElementFactory::list_get_elements(
+            gst_ffi::GST_ELEMENT_FACTORY_TYPE_PARSER |
+            gst_ffi::GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO,
+            gst::Rank::None,
+        );
+        let video_decoder_factories = gst::ElementFactory::list_get_elements(
+            gst_ffi::GST_ELEMENT_FACTORY_TYPE_DECODER |
+            gst_ffi::GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO,
+            gst::Rank::Marginal,
+        );
+        let video_parser_factories = gst::ElementFactory::list_get_elements(
+            gst_ffi::GST_ELEMENT_FACTORY_TYPE_PARSER |
+            gst_ffi::GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO,
+            gst::Rank::Marginal,
+        );
+        let demux_factories = gst::ElementFactory::list_get_elements(
+            gst_ffi::GST_ELEMENT_FACTORY_TYPE_DEMUXER,
+            gst::Rank::Marginal,
+        );
+
+        if has_element_for_media_type(&audio_decoder_factories, "audio/mpeg, mpegversion=(int)4") {
+            self.supported_mime_types.insert("audio/aac");
+            self.supported_mime_types.insert("audio/mp4");
+            self.supported_mime_types.insert("audio/x-m4a");
+            self.supported_codecs.insert("mpeg");
+            self.supported_codecs.insert("mp4a*");
+        }
+
+        let is_opus_supported = has_element_for_media_type(&audio_decoder_factories, "audio/x-opus");
+        if is_opus_supported && has_element_for_media_type(&audio_parser_factories, "audio/x-opus") {
+            self.supported_mime_types.insert("audio/opus");
+            self.supported_codecs.insert("opus");
+            self.supported_codecs.insert("x-opus");
+        }
+
+        let is_vorbis_supported = has_element_for_media_type(&audio_decoder_factories, "audio/x-vorbis");
+        if is_vorbis_supported && has_element_for_media_type(&audio_parser_factories, "audio/x-vorbis") {
+            self.supported_codecs.insert("vorbis");
+            self.supported_codecs.insert("x-vorbis");
+        }
+
+        if has_element_for_media_type(&demux_factories, "video/x-matroska") {
+            let is_vp8_decoder_available = has_element_for_media_type(&video_decoder_factories, "video/x-vp8");
+            let is_vp9_decoder_available = has_element_for_media_type(&video_decoder_factories, "video/x-vp9");
+
+            if is_vp8_decoder_available || is_vp9_decoder_available {
+                self.supported_mime_types.insert("video/webm");
+            }
+
+            if is_vp8_decoder_available {
+                self.supported_codecs.insert("vp8");
+                self.supported_codecs.insert("x-vp8");
+                self.supported_codecs.insert("vp8.0");
+            }
+
+            if is_vp9_decoder_available {
+                self.supported_codecs.insert("vp9");
+                self.supported_codecs.insert("x-vp9");
+                self.supported_codecs.insert("vp9.0");
+            }
+
+            if is_opus_supported {
+                self.supported_mime_types.insert("audio/webm");
+            }
+        }
+
+        let is_h264_decoder_available = has_element_for_media_type(
+            &video_decoder_factories,
+            "video/x-h264, profile=(string){ constrained-baseline, baseline, high }"
+        );
+        if is_h264_decoder_available && has_element_for_media_type(&video_parser_factories, "video/x-h264") {
+            self.supported_mime_types.insert("video/mp4");
+            self.supported_mime_types.insert("video/x-m4v");
+            self.supported_codecs.insert("x-h264");
+            self.supported_codecs.insert("avc*");
+            self.supported_codecs.insert("mp4v*");
+        }
+
+        if has_element_for_media_type(&audio_decoder_factories, "audio/midi") {
+            self.supported_mime_types.insert("audio/midi");
+            self.supported_mime_types.insert("audio/riff-midi");
+        }
+
+        if has_element_for_media_type(&audio_decoder_factories, "audio/x-ac3") {
+            self.supported_mime_types.insert("audio/x-ac3");
+        }
+
+        if has_element_for_media_type(&audio_decoder_factories, "audio/x-flac") {
+            self.supported_mime_types.insert("audio/flac");
+            self.supported_mime_types.insert("audio/x-flac");
+        }
+
+        if has_element_for_media_type(&audio_decoder_factories, "audio/x-speex") {
+            self.supported_mime_types.insert("audio/speex");
+            self.supported_mime_types.insert("audio/x-speex");
+        }
+        
+        if has_element_for_media_type(&audio_decoder_factories, "audio/x-wavpack") {
+            self.supported_mime_types.insert("audio/x-wavpack");
+        }
+
+        if has_element_for_media_type(&video_decoder_factories, "video/mpeg, mpegversion=(int){1,2}, systemstream=(boolean)false") {
+            self.supported_mime_types.insert("video/mpeg");
+            self.supported_codecs.insert("mpeg");
+        }
+
+        if has_element_for_media_type(&video_decoder_factories, "video/x-flash-video") {
+            self.supported_mime_types.insert("video/flv");
+            self.supported_mime_types.insert("video/x-flv");
+        }
+
+        if has_element_for_media_type(&video_decoder_factories, "video/x-msvideocodec") {
+            self.supported_mime_types.insert("video/x-msvideo");
+        }
+
+        if has_element_for_media_type(&demux_factories, "application/x-hls") {
+            self.supported_mime_types.insert("application/vnd.apple.mpegurl");
+            self.supported_mime_types.insert("application/x-mpegurl");
+        }
+
+        if has_element_for_media_type(&demux_factories, "application/x-wav") {
+            self.supported_mime_types.insert("audio/wav");
+            self.supported_mime_types.insert("audio/vnd.wav");
+            self.supported_mime_types.insert("audio/x-wav");
+            self.supported_codecs.insert("1");
+        }
+
+        if has_element_for_media_type(&demux_factories, "video/quicktime, variant=(string)3gpp") {
+            self.supported_mime_types.insert("video/3gpp");
+        }
+
+        if has_element_for_media_type(&demux_factories, "application/ogg") {
+            self.supported_mime_types.insert("application/ogg");
+
+            if is_vorbis_supported {
+                self.supported_mime_types.insert("audio/ogg");
+                self.supported_mime_types.insert("audio/x-vorbis+ogg");
+            }
+
+            if has_element_for_media_type(&audio_decoder_factories, "audio/x-speex") {
+                self.supported_mime_types.insert("audio/ogg");
+                self.supported_codecs.insert("speex");
+            }
+
+            if has_element_for_media_type(&video_decoder_factories, "video/x-theora") {
+                self.supported_mime_types.insert("video/ogg");
+                self.supported_codecs.insert("theora");
+            }
+        }
+
+        let mut is_audio_mpeg_supported = false;
+        if has_element_for_media_type(&audio_decoder_factories, "audio/mpeg, mpegversion=(int)1, layer=(int)[1, 3]") {
+            is_audio_mpeg_supported = true;
+            self.supported_mime_types.insert("audio/mp1");
+            self.supported_mime_types.insert("audio/mp3");
+            self.supported_mime_types.insert("audio/x-mp3");
+            self.supported_codecs.insert("audio/mp3");
+        }
+
+        if has_element_for_media_type(&audio_decoder_factories, "audio/mpeg, mpegversion=(int)2") {
+            is_audio_mpeg_supported = true;
+            self.supported_mime_types.insert("audio/mp2");
+        }
+
+        is_audio_mpeg_supported |= self.is_container_type_supported("video/mp4");
+        if is_audio_mpeg_supported {
+            self.supported_mime_types.insert("audio/mpeg");
+            self.supported_mime_types.insert("audio/x-mpeg");
+        }
+
+        let is_matroska_supported = has_element_for_media_type(&demux_factories, "video/x-matroska");
+        if is_matroska_supported {
+            self.supported_mime_types.insert("video/x-matroska");
+
+            if has_element_for_media_type(&video_decoder_factories, "video/x-vp10") {
+                self.supported_mime_types.insert("video/webm");
+            }
+        }
+
+        if (is_matroska_supported || self.is_container_type_supported("video/mp4")) &&
+            has_element_for_media_type(&video_decoder_factories, "video/x-av1") {
+            self.supported_codecs.insert("av01*");
+        }
+    }
+}
+
+fn has_element_for_media_type(
+    factories: &Vec<gst::ElementFactory>,
+    media_type: &str,
+) -> bool {
+    match gst::caps::Caps::from_string(media_type) {
+        Some(caps) => {
+            let matching_factories = gst::ElementFactory::list_filter(
+                &factories,
+                &caps,
+                gst::PadDirection::Sink,
+                false,
+            );
+            matching_factories.len() > 0
+        }
+        None => false,
+    }
+}

--- a/servo-media/lib.rs
+++ b/servo-media/lib.rs
@@ -31,6 +31,14 @@ pub trait Backend: Send + Sync {
     fn create_videoinput_stream(&self, set: MediaTrackConstraintSet) -> Option<MediaStreamId>;
     fn create_audio_context(&self, options: AudioContextOptions) -> AudioContext;
     fn create_webrtc(&self, signaller: Box<WebRtcSignaller>) -> WebRtcController;
+    fn can_play_type(&self, media_type: &str) -> SupportsMediaType;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SupportsMediaType {
+    Maybe,
+    No,
+    Probably,
 }
 
 impl ServoMedia {


### PR DESCRIPTION
This is related to https://github.com/servo/servo/issues/22299. I tried to follow WebKit's [implementation](https://github.com/WebKit/webkit/blob/ae5a8bdded113530fe844e01ad9c0e72ce85dbe2/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp#L304) of a similar function, as suggested by @ferjm in the issue's comments.