### PR TITLE
Handle buffer offset in servosrc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,6 +1975,7 @@ dependencies = [
  "gstreamer 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-app 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-audio 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gstreamer-base 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-player 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-sdp 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-sdp-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -41,6 +41,9 @@ version = "0.13"
 [dependencies.gstreamer-audio]
 version = "0.13"
 
+[dependencies.gstreamer-base]
+version = "0.13"
+
 [dependencies.gstreamer-player]
 version = "0.13"
 

--- a/backends/gstreamer/lib.rs
+++ b/backends/gstreamer/lib.rs
@@ -14,6 +14,7 @@ extern crate glib;
 extern crate gstreamer as gst;
 extern crate gstreamer_app as gst_app;
 extern crate gstreamer_audio as gst_audio;
+extern crate gstreamer_base as gst_base;
 extern crate gstreamer_player as gst_player;
 extern crate gstreamer_sdp as gst_sdp;
 extern crate gstreamer_video as gst_video;

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -489,8 +489,11 @@ impl GStreamerPlayer {
 
         let observers = self.observers.clone();
         // Handle `error` signal
-        inner.lock().unwrap().player.connect_error(move |_, _| {
-            observers.lock().unwrap().notify(PlayerEvent::Error);
+        inner.lock().unwrap().player.connect_error(move |_, error| {
+            observers
+                .lock()
+                .unwrap()
+                .notify(PlayerEvent::Error(error.to_string()));
         });
 
         let observers = self.observers.clone();

--- a/backends/gstreamer/source.rs
+++ b/backends/gstreamer/source.rs
@@ -152,8 +152,6 @@ mod imp {
         }
 
         inner_appsrc_proxy!(end_of_stream, Result<gst::FlowSuccess, gst::FlowError>);
-        inner_appsrc_proxy!(get_current_level_bytes, u64);
-        inner_appsrc_proxy!(get_max_bytes, u64);
         inner_appsrc_proxy!(set_callbacks, callbacks, gst_app::AppSrcCallbacks, ());
 
         fn query(
@@ -387,8 +385,6 @@ impl ServoSrc {
     }
 
     inner_servosrc_proxy!(end_of_stream, Result<gst::FlowSuccess, gst::FlowError>);
-    inner_servosrc_proxy!(get_current_level_bytes, u64);
-    inner_servosrc_proxy!(get_max_bytes, u64);
     inner_servosrc_proxy!(set_callbacks, callbacks, gst_app::AppSrcCallbacks, ());
 }
 

--- a/examples/play_media_stream.rs
+++ b/examples/play_media_stream.rs
@@ -24,8 +24,8 @@ fn run_example(servo_media: Arc<ServoMedia>) {
                 println!("\nEOF");
                 break;
             }
-            PlayerEvent::Error => {
-                println!("\nError");
+            PlayerEvent::Error(ref s) => {
+                println!("\nError: {:?}", s);
                 break;
             }
             PlayerEvent::MetadataUpdated(ref m) => {

--- a/examples/player/player_wrapper.rs
+++ b/examples/player/player_wrapper.rs
@@ -4,7 +4,7 @@
 
 use ipc_channel::ipc;
 use servo_media::player::frame::{Frame, FrameRenderer};
-use servo_media::player::{GlContext, Player, PlayerEvent, StreamType};
+use servo_media::player::{GlContext, Player, PlayerError, PlayerEvent, StreamType};
 use servo_media::ServoMedia;
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
@@ -123,13 +123,19 @@ impl PlayerWrapper {
                                 end_file.store(true, Ordering::Relaxed);
                             }
                             Ok(size) => {
-                                if let Err(e) = player
+                                match player
                                     .lock()
                                     .unwrap()
                                     .push_data(Vec::from(&buffer[0..size]))
                                 {
-                                    println!("Can't push data: {:?}", e);
-                                    //break;
+                                    Ok(_) => (),
+                                    Err(PlayerError::EnoughData) => {
+                                        print!("!");
+                                    }
+                                    Err(e) => {
+                                        println!("Can't push data: {:?}", e);
+                                        break;
+                                    }
                                 }
                             }
                             Err(e) => {

--- a/examples/player/player_wrapper.rs
+++ b/examples/player/player_wrapper.rs
@@ -156,8 +156,8 @@ impl PlayerWrapper {
                             println!("EOF");
                             break;
                         }
-                        PlayerEvent::Error => {
-                            println!("Player's Error");
+                        PlayerEvent::Error(ref s) => {
+                            println!("Player's Error {:?}", s);
                             break;
                         }
                         PlayerEvent::MetadataUpdated(ref m) => {

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -99,8 +99,8 @@ fn run_example(servo_media: Arc<ServoMedia>) {
                 println!("\nEOF");
                 break;
             }
-            PlayerEvent::Error => {
-                println!("\nError");
+            PlayerEvent::Error(ref s) => {
+                println!("\nError {:?}", s);
                 break;
             }
             PlayerEvent::MetadataUpdated(ref m) => {

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -43,7 +43,7 @@ pub enum PlayerEvent {
     EndOfStream,
     /// The player has enough data. The client should stop pushing data into.
     EnoughData,
-    Error,
+    Error(String),
     FrameUpdated,
     MetadataUpdated(metadata::Metadata),
     /// The internal player queue is running out of data. The client should start


### PR DESCRIPTION
Seeking requires a strict handling of each buffer offset. Though appsrc do some offset handling, but only for live stream (not seeking). When random-access is enabled the application must take care of marking each buffer offset correctly.

This patch extends servosrc's method push_buffer() so it will count the current offset and stamps it on the pushed buffer. Also, it honors the buffer's block size defined in appsrc, splitting the input data in several buffers if it's bigger, fixing some problems with the buffering mechanism in playbin.

When a seek operation is done, the current media offset must be updated with the requested position.

As per media/player design, it is required that the user must push synchronized the data from the requested position by the seek.