### PR TITLE
Add trait PlayerGLContext

### DIFF
--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -15,7 +15,8 @@ use servo_media_audio::decoder::{AudioDecoder, AudioDecoderCallbacks, AudioDecod
 use servo_media_audio::render_thread::AudioRenderThreadMsg;
 use servo_media_audio::sink::{AudioSink, AudioSinkError};
 use servo_media_audio::AudioBackend;
-use servo_media_player::{frame, GlContext, Player, PlayerError, PlayerEvent, StreamType};
+use servo_media_player::context::PlayerGLContext;
+use servo_media_player::{frame, Player, PlayerError, PlayerEvent, StreamType};
 use servo_media_streams::capture::MediaTrackConstraintSet;
 use servo_media_streams::registry::{register_stream, unregister_stream, MediaStreamId};
 use servo_media_streams::{MediaOutput, MediaStream};
@@ -65,7 +66,7 @@ impl Backend for DummyBackend {
         }))))
     }
 
-    fn create_player(&self, _: StreamType) -> Box<Player> {
+    fn create_player(&self, _: StreamType, _: Box<PlayerGLContext>) -> Box<Player> {
         Box::new(DummyPlayer)
     }
 
@@ -135,9 +136,6 @@ impl Player for DummyPlayer {
     fn buffered(&self) -> Result<Vec<Range<f64>>, PlayerError> {
         Ok(vec![])
     }
-    fn set_gl_params(&self, _: GlContext, _: usize) -> Result<(), ()> {
-        Err(())
-    }
 
     fn shutdown(&self) -> Result<(), PlayerError> {
         Ok(())
@@ -145,6 +143,10 @@ impl Player for DummyPlayer {
 
     fn set_stream(&self, _: &MediaStreamId) -> Result<(), PlayerError> {
         Ok(())
+    }
+
+    fn render_use_gl(&self) -> bool {
+        false
     }
 }
 

--- a/backends/gstreamer/lib.rs
+++ b/backends/gstreamer/lib.rs
@@ -51,6 +51,7 @@ use servo_media_audio::context::{AudioContext, AudioContextOptions};
 use servo_media_audio::decoder::AudioDecoder;
 use servo_media_audio::sink::AudioSinkError;
 use servo_media_audio::AudioBackend;
+use servo_media_player::context::PlayerGLContext;
 use servo_media_player::{Player, StreamType};
 use servo_media_streams::capture::MediaTrackConstraintSet;
 use servo_media_streams::registry::MediaStreamId;
@@ -64,8 +65,12 @@ lazy_static! {
 pub struct GStreamerBackend;
 
 impl Backend for GStreamerBackend {
-    fn create_player(&self, stream_type: StreamType) -> Box<Player> {
-        Box::new(player::GStreamerPlayer::new(stream_type))
+    fn create_player(
+        &self,
+        stream_type: StreamType,
+        gl_context: Box<PlayerGLContext>,
+    ) -> Box<Player> {
+        Box::new(player::GStreamerPlayer::new(stream_type, gl_context))
     }
 
     fn create_audio_context(&self, options: AudioContextOptions) -> AudioContext {

--- a/backends/gstreamer/render.rs
+++ b/backends/gstreamer/render.rs
@@ -6,8 +6,9 @@ use gst_video;
 use std::sync::Arc;
 
 use servo_media_gstreamer_render::Render;
+use servo_media_player::context::PlayerGLContext;
 use servo_media_player::frame::{Buffer, Frame, FrameData};
-use servo_media_player::{GlContext, PlayerError};
+use servo_media_player::PlayerError;
 
 #[cfg(any(
     target_os = "linux",
@@ -22,8 +23,8 @@ mod platform {
 
     use super::*;
 
-    pub fn create_render(context: GlContext, display: usize) -> Option<Render> {
-        Render::new(context, display)
+    pub fn create_render(gl_context: Box<PlayerGLContext>) -> Option<Render> {
+        Render::new(gl_context)
     }
 }
 
@@ -36,13 +37,14 @@ mod platform {
 )))]
 mod platform {
     use servo_media_gstreamer_render::Render as RenderTrait;
+    use servo_media_player::context::PlayerGLContext;
     use servo_media_player::frame::Frame;
-    use servo_media_player::{GlContext, PlayerError};
+    use servo_media_player::PlayerError;
 
     pub struct RenderDummy();
     pub type Render = RenderDummy;
 
-    pub fn create_render(_: GlContext, _: usize) -> Option<RenderDummy> {
+    pub fn create_render(_: Box<PlayerGLContext>) -> Option<RenderDummy> {
         None
     }
 
@@ -79,9 +81,9 @@ pub struct GStreamerRender {
 }
 
 impl GStreamerRender {
-    pub fn new(gl_context: GlContext, display_native: usize) -> Self {
+    pub fn new(gl_context: Box<PlayerGLContext>) -> Self {
         GStreamerRender {
-            render: platform::create_render(gl_context, display_native),
+            render: platform::create_render(gl_context),
         }
     }
 

--- a/examples/play_media_stream.rs
+++ b/examples/play_media_stream.rs
@@ -3,12 +3,26 @@ extern crate servo_media;
 extern crate servo_media_auto;
 
 use ipc_channel::ipc;
+use servo_media::player::context::{GlContext, NativeDisplay, PlayerGLContext};
 use servo_media::player::{PlayerEvent, StreamType};
 use servo_media::ServoMedia;
 use std::sync::{Arc, Mutex};
 
+struct PlayerContextDummy();
+impl PlayerGLContext for PlayerContextDummy {
+    fn get_gl_context(&self) -> GlContext {
+        return GlContext::Unknown;
+    }
+
+    fn get_native_display(&self) -> NativeDisplay {
+        return NativeDisplay::Unknown;
+    }
+}
+
 fn run_example(servo_media: Arc<ServoMedia>) {
-    let player = Arc::new(Mutex::new(servo_media.create_player(StreamType::Stream)));
+    let player = Arc::new(Mutex::new(
+        servo_media.create_player(StreamType::Stream, Box::new(PlayerContextDummy())),
+    ));
 
     let (sender, receiver) = ipc::channel().unwrap();
     player.lock().unwrap().register_event_handler(sender);

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -3,6 +3,7 @@ extern crate servo_media;
 extern crate servo_media_auto;
 
 use ipc_channel::ipc;
+use servo_media::player::context::{GlContext, NativeDisplay, PlayerGLContext};
 use servo_media::player::{PlayerEvent, StreamType};
 use servo_media::ServoMedia;
 use std::env;
@@ -15,8 +16,21 @@ use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+struct PlayerContextDummy();
+impl PlayerGLContext for PlayerContextDummy {
+    fn get_gl_context(&self) -> GlContext {
+        return GlContext::Unknown;
+    }
+
+    fn get_native_display(&self) -> NativeDisplay {
+        return NativeDisplay::Unknown;
+    }
+}
+
 fn run_example(servo_media: Arc<ServoMedia>) {
-    let player = Arc::new(Mutex::new(servo_media.create_player(StreamType::Seekable)));
+    let player = Arc::new(Mutex::new(
+        servo_media.create_player(StreamType::Seekable, Box::new(PlayerContextDummy())),
+    ));
     let args: Vec<_> = env::args().collect();
     let default = "./examples/resources/viper_cut.ogg";
     let filename: &str = if args.len() == 2 {

--- a/player/context.rs
+++ b/player/context.rs
@@ -9,7 +9,7 @@
 //! for the GStreamer backend.
 //!
 //! The client application should implement this trait and pass the
-//! trait object to its `player` intsance.
+//! trait object to its `player` instance.
 
 pub enum GlContext {
     /// The EGL platform used primarily with the X11, Wayland and

--- a/player/context.rs
+++ b/player/context.rs
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! `PlayerGLContext` is a trait to be used to pass the GL context for
+//! rendering purposes.
+//!
+//! The current consumer of this trait is the GL rendering mechanism
+//! for the GStreamer backend.
+//!
+//! The client application should implement this trait and pass the
+//! trait object to its `player` intsance.
+
+pub enum GlContext {
+    /// The EGL platform used primarily with the X11, Wayland and
+    /// Android window systems as well as on embedded Linux.
+    Egl(usize),
+    /// The GLX platform used primarily with the X11 window system.
+    Glx(usize),
+    Unknown,
+}
+
+pub enum NativeDisplay {
+    /// The EGLDisplay memory address
+    Egl(usize),
+    /// XDisplay memory address
+    X11(usize),
+    /// wl_display memory address
+    Wayland(usize),
+    Headless,
+    Unknown,
+}
+
+pub trait PlayerGLContext: Send {
+    /// Returns the GL context living pointer wrapped by `GlContext`
+    fn get_gl_context(&self) -> GlContext;
+    /// Returns the living pointer to the native display structure
+    /// wrapped by `NativeDisplay`.
+    fn get_native_display(&self) -> NativeDisplay;
+}

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -3,6 +3,7 @@ extern crate ipc_channel;
 extern crate serde_derive;
 extern crate servo_media_streams as streams;
 
+pub mod context;
 pub mod frame;
 pub mod metadata;
 
@@ -67,15 +68,6 @@ pub enum StreamType {
     Seekable,
 }
 
-pub enum GlContext {
-    // The EGL platform used primarily with the X11, Wayland and
-    // Android window systems as well as on embedded Linux.
-    Egl(usize),
-    // The GLX platform used primarily with the X11 window system.
-    Glx(usize),
-    Unknown,
-}
-
 pub trait Player: Send {
     fn register_event_handler(&self, sender: IpcSender<PlayerEvent>);
     fn register_frame_renderer(&self, renderer: Arc<Mutex<frame::FrameRenderer>>);
@@ -91,10 +83,11 @@ pub trait Player: Send {
     fn end_of_stream(&self) -> Result<(), PlayerError>;
     /// Get the list of time ranges in seconds that have been buffered.
     fn buffered(&self) -> Result<Vec<Range<f64>>, PlayerError>;
-    fn set_gl_params(&self, gl_context: GlContext, gl_display: usize) -> Result<(), ()>;
     /// Shut the player down. Stops playback and free up resources.
     fn shutdown(&self) -> Result<(), PlayerError>;
     /// Set the stream to be played by the player.
     /// This method requires the player to be constructed with StreamType::Stream.
     fn set_stream(&self, stream: &MediaStreamId) -> Result<(), PlayerError>;
+    /// If player's rendering draws using GL textures
+    fn render_use_gl(&self) -> bool;
 }

--- a/servo-media/lib.rs
+++ b/servo-media/lib.rs
@@ -7,6 +7,7 @@ use std::ops::Deref;
 use std::sync::{self, Arc, Mutex, Once};
 
 use audio::context::{AudioContext, AudioContextOptions};
+use player::context::PlayerGLContext;
 use player::{Player, StreamType};
 use streams::capture::MediaTrackConstraintSet;
 use streams::registry::MediaStreamId;
@@ -23,7 +24,11 @@ pub trait BackendInit {
 }
 
 pub trait Backend: Send + Sync {
-    fn create_player(&self, stream_type: StreamType) -> Box<Player>;
+    fn create_player(
+        &self,
+        stream_type: StreamType,
+        gl_context: Box<PlayerGLContext>,
+    ) -> Box<Player>;
     fn create_audiostream(&self) -> MediaStreamId;
     fn create_videostream(&self) -> MediaStreamId;
     fn create_stream_output(&self) -> Box<MediaOutput>;


### PR DESCRIPTION
PlayerGLContext will provide the GL context paratemers required to
create a Render object. If those parameters are supported by the
Render, it will setup a GL rendering pipeline and will handle the
frames in form of GL Textures.

The PlayerGLContext is passed to the player at its instantiation.