### PR TITLE
PlayerGLContext does not need to be thread aware

### DIFF
--- a/player/context.rs
+++ b/player/context.rs
@@ -31,7 +31,7 @@ pub enum NativeDisplay {
     Unknown,
 }
 
-pub trait PlayerGLContext: Send {
+pub trait PlayerGLContext {
     /// Returns the GL context living pointer wrapped by `GlContext`
     fn get_gl_context(&self) -> GlContext;
     /// Returns the living pointer to the native display structure


### PR DESCRIPTION
Fixes: #251

As far as I have played, there's no need to make PlayerGLContext trait thread aware, so we could avoid the changes in https://github.com/servo/media/pull/253