### PR TITLE
Add support for simple media capture mocking

### DIFF
--- a/servo-media/lib.rs
+++ b/servo-media/lib.rs
@@ -37,6 +37,7 @@ pub trait Backend: Send + Sync {
     fn create_audio_context(&self, options: AudioContextOptions) -> AudioContext;
     fn create_webrtc(&self, signaller: Box<WebRtcSignaller>) -> WebRtcController;
     fn can_play_type(&self, media_type: &str) -> SupportsMediaType;
+    fn set_capture_mocking(&self, _mock: bool) {}
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
This should be enough to get some of the webrtc tests running on CI.

This doesn't capsfilter, so we may get test failures due to that.

r? @jdm @ferjm