### PR TITLE
Add dyn clause when using trait object

### DIFF
--- a/audio/analyser_node.rs
+++ b/audio/analyser_node.rs
@@ -8,11 +8,11 @@ use std::f32::consts::PI;
 #[derive(AudioNodeCommon)]
 pub(crate) struct AnalyserNode {
     channel_info: ChannelInfo,
-    callback: Box<FnMut(Block) + Send>,
+    callback: Box<dyn FnMut(Block) + Send>,
 }
 
 impl AnalyserNode {
-    pub fn new(callback: Box<FnMut(Block) + Send>, channel_info: ChannelInfo) -> Self {
+    pub fn new(callback: Box<dyn FnMut(Block) + Send>, channel_info: ChannelInfo) -> Self {
         Self {
             callback,
             channel_info,

--- a/audio/decoder.rs
+++ b/audio/decoder.rs
@@ -18,7 +18,7 @@ pub enum AudioDecoderError {
 pub struct AudioDecoderCallbacks {
     pub eos: Mutex<Option<SendBoxFnOnce<'static, ()>>>,
     pub error: Mutex<Option<SendBoxFnOnce<'static, (AudioDecoderError,)>>>,
-    pub progress: Option<Box<Fn(Box<AsRef<[f32]>>, u32) + Send + Sync + 'static>>,
+    pub progress: Option<Box<dyn Fn(Box<dyn AsRef<[f32]>>, u32) + Send + Sync + 'static>>,
     pub ready: Mutex<Option<SendBoxFnOnce<'static, (u32,)>>>,
 }
 
@@ -48,7 +48,7 @@ impl AudioDecoderCallbacks {
         };
     }
 
-    pub fn progress(&self, buffer: Box<AsRef<[f32]>>, channel: u32) {
+    pub fn progress(&self, buffer: Box<dyn AsRef<[f32]>>, channel: u32) {
         match self.progress {
             None => return,
             Some(ref callback) => callback(buffer, channel),
@@ -67,7 +67,7 @@ impl AudioDecoderCallbacks {
 pub struct AudioDecoderCallbacksBuilder {
     eos: Option<SendBoxFnOnce<'static, ()>>,
     error: Option<SendBoxFnOnce<'static, (AudioDecoderError,)>>,
-    progress: Option<Box<Fn(Box<AsRef<[f32]>>, u32) + Send + Sync + 'static>>,
+    progress: Option<Box<dyn Fn(Box<dyn AsRef<[f32]>>, u32) + Send + Sync + 'static>>,
     ready: Option<SendBoxFnOnce<'static, (u32,)>>,
 }
 
@@ -86,7 +86,7 @@ impl AudioDecoderCallbacksBuilder {
         }
     }
 
-    pub fn progress<F: Fn(Box<AsRef<[f32]>>, u32) + Send + Sync + 'static>(
+    pub fn progress<F: Fn(Box<dyn AsRef<[f32]>>, u32) + Send + Sync + 'static>(
         self,
         progress: F,
     ) -> Self {

--- a/audio/graph.rs
+++ b/audio/graph.rs
@@ -98,7 +98,7 @@ pub struct AudioGraph {
 }
 
 pub(crate) struct Node {
-    node: RefCell<Box<AudioNodeEngine>>,
+    node: RefCell<Box<dyn AudioNodeEngine>>,
 }
 
 /// An edge in the graph
@@ -170,7 +170,7 @@ impl AudioGraph {
     }
 
     /// Create a node, obtain its id
-    pub(crate) fn add_node(&mut self, node: Box<AudioNodeEngine>) -> NodeId {
+    pub(crate) fn add_node(&mut self, node: Box<dyn AudioNodeEngine>) -> NodeId {
         NodeId(self.graph.add_node(Node::new(node)))
     }
 
@@ -488,13 +488,13 @@ impl AudioGraph {
     }
 
     /// Obtain a mutable reference to a node
-    pub(crate) fn node_mut(&self, ix: NodeId) -> RefMut<Box<AudioNodeEngine>> {
+    pub(crate) fn node_mut(&self, ix: NodeId) -> RefMut<Box<dyn AudioNodeEngine>> {
         self.graph[ix.0].node.borrow_mut()
     }
 }
 
 impl Node {
-    pub fn new(node: Box<AudioNodeEngine>) -> Self {
+    pub fn new(node: Box<dyn AudioNodeEngine>) -> Self {
         Node {
             node: RefCell::new(node),
         }

--- a/audio/lib.rs
+++ b/audio/lib.rs
@@ -36,6 +36,6 @@ pub mod stereo_panner;
 
 pub trait AudioBackend {
     type Sink: sink::AudioSink + 'static;
-    fn make_decoder() -> Box<decoder::AudioDecoder>;
+    fn make_decoder() -> Box<dyn decoder::AudioDecoder>;
     fn make_sink() -> Result<Self::Sink, sink::AudioSinkError>;
 }

--- a/audio/node.rs
+++ b/audio/node.rs
@@ -13,7 +13,7 @@ use std::sync::mpsc::Sender;
 
 /// Information required to construct an audio node
 pub enum AudioNodeInit {
-    AnalyserNode(Box<FnMut(Block) + Send>),
+    AnalyserNode(Box<dyn FnMut(Block) + Send>),
     BiquadFilterNode(BiquadFilterNodeOptions),
     AudioBuffer,
     AudioBufferSourceNode(AudioBufferSourceNodeOptions),

--- a/audio/offline_sink.rs
+++ b/audio/offline_sink.rs
@@ -18,7 +18,7 @@ pub struct OfflineAudioSink {
     has_enough_data: Cell<bool>,
     length: usize,
     rendered_blocks: Cell<usize>,
-    eos_callback: RefCell<Option<Box<Fn(Box<AsRef<[f32]>>) + Send + Sync + 'static>>>,
+    eos_callback: RefCell<Option<Box<dyn Fn(Box<dyn AsRef<[f32]>>) + Send + Sync + 'static>>>,
 }
 
 impl OfflineAudioSink {
@@ -91,7 +91,10 @@ impl AudioSink for OfflineAudioSink {
         Ok(())
     }
 
-    fn set_eos_callback(&self, callback: Box<Fn(Box<AsRef<[f32]>>) + Send + Sync + 'static>) {
+    fn set_eos_callback(
+        &self,
+        callback: Box<dyn Fn(Box<dyn AsRef<[f32]>>) + Send + Sync + 'static>,
+    ) {
         *self.eos_callback.borrow_mut() = Some(callback);
     }
 }

--- a/audio/sink.rs
+++ b/audio/sink.rs
@@ -22,5 +22,8 @@ pub trait AudioSink {
     fn stop(&self) -> Result<(), AudioSinkError>;
     fn has_enough_data(&self) -> bool;
     fn push_data(&self, chunk: Chunk) -> Result<(), AudioSinkError>;
-    fn set_eos_callback(&self, callback: Box<Fn(Box<AsRef<[f32]>>) + Send + Sync + 'static>);
+    fn set_eos_callback(
+        &self,
+        callback: Box<dyn Fn(Box<dyn AsRef<[f32]>>) + Send + Sync + 'static>,
+    );
 }

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -32,7 +32,7 @@ use std::sync::{Arc, Mutex};
 pub struct DummyBackend;
 
 impl BackendInit for DummyBackend {
-    fn init() -> Box<Backend> {
+    fn init() -> Box<dyn Backend> {
         Box::new(DummyBackend)
     }
 }
@@ -50,7 +50,7 @@ impl Backend for DummyBackend {
         })))
     }
 
-    fn create_stream_output(&self) -> Box<MediaOutput> {
+    fn create_stream_output(&self) -> Box<dyn MediaOutput> {
         Box::new(DummyMediaOutput)
     }
 
@@ -70,9 +70,9 @@ impl Backend for DummyBackend {
         &self,
         _: StreamType,
         _: IpcSender<PlayerEvent>,
-        _: Option<Arc<Mutex<frame::FrameRenderer>>>,
-        _: Box<PlayerGLContext>,
-    ) -> Box<Player> {
+        _: Option<Arc<Mutex<dyn frame::FrameRenderer>>>,
+        _: Box<dyn PlayerGLContext>,
+    ) -> Box<dyn Player> {
         Box::new(DummyPlayer)
     }
 
@@ -80,7 +80,7 @@ impl Backend for DummyBackend {
         AudioContext::new::<Self>(options)
     }
 
-    fn create_webrtc(&self, signaller: Box<WebRtcSignaller>) -> WebRtcController {
+    fn create_webrtc(&self, signaller: Box<dyn WebRtcSignaller>) -> WebRtcController {
         WebRtcController::new::<Self>(signaller)
     }
 
@@ -91,7 +91,7 @@ impl Backend for DummyBackend {
 
 impl AudioBackend for DummyBackend {
     type Sink = DummyAudioSink;
-    fn make_decoder() -> Box<AudioDecoder> {
+    fn make_decoder() -> Box<dyn AudioDecoder> {
         Box::new(DummyAudioDecoder)
     }
 
@@ -156,7 +156,7 @@ impl Player for DummyPlayer {
 impl WebRtcBackend for DummyBackend {
     type Controller = DummyWebRtcController;
     fn construct_webrtc_controller(
-        _: Box<WebRtcSignaller>,
+        _: Box<dyn WebRtcSignaller>,
         _: WebRtcController,
     ) -> Self::Controller {
         DummyWebRtcController
@@ -174,10 +174,10 @@ pub struct DummyMediaStream {
 }
 
 impl MediaStream for DummyMediaStream {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
-    fn as_mut_any(&mut self) -> &mut Any {
+    fn as_mut_any(&mut self) -> &mut dyn Any {
         self
     }
     fn set_id(&mut self, _: MediaStreamId) {}
@@ -211,7 +211,7 @@ impl AudioSink for DummyAudioSink {
     fn push_data(&self, _: Chunk) -> Result<(), AudioSinkError> {
         Ok(())
     }
-    fn set_eos_callback(&self, _: Box<Fn(Box<AsRef<[f32]>>) + Send + Sync + 'static>) {}
+    fn set_eos_callback(&self, _: Box<dyn Fn(Box<dyn AsRef<[f32]>>) + Send + Sync + 'static>) {}
 }
 
 pub struct DummyMediaOutput;

--- a/backends/gstreamer/audio_sink.rs
+++ b/backends/gstreamer/audio_sink.rs
@@ -186,7 +186,7 @@ impl AudioSink for GStreamerAudioSink {
             .map_err(|_| AudioSinkError::BufferPushFailed)
     }
 
-    fn set_eos_callback(&self, _: Box<Fn(Box<AsRef<[f32]>>) + Send + Sync + 'static>) {}
+    fn set_eos_callback(&self, _: Box<dyn Fn(Box<dyn AsRef<[f32]>>) + Send + Sync + 'static>) {}
 }
 
 impl Drop for GStreamerAudioSink {

--- a/backends/gstreamer/lib.rs
+++ b/backends/gstreamer/lib.rs
@@ -75,9 +75,9 @@ impl Backend for GStreamerBackend {
         &self,
         stream_type: StreamType,
         sender: IpcSender<PlayerEvent>,
-        renderer: Option<Arc<Mutex<FrameRenderer>>>,
-        gl_context: Box<PlayerGLContext>,
-    ) -> Box<Player> {
+        renderer: Option<Arc<Mutex<dyn FrameRenderer>>>,
+        gl_context: Box<dyn PlayerGLContext>,
+    ) -> Box<dyn Player> {
         Box::new(player::GStreamerPlayer::new(
             stream_type,
             sender,
@@ -90,7 +90,7 @@ impl Backend for GStreamerBackend {
         AudioContext::new::<Self>(options)
     }
 
-    fn create_webrtc(&self, signaller: Box<WebRtcSignaller>) -> WebRtcController {
+    fn create_webrtc(&self, signaller: Box<dyn WebRtcSignaller>) -> WebRtcController {
         WebRtcController::new::<Self>(signaller)
     }
 
@@ -102,7 +102,7 @@ impl Backend for GStreamerBackend {
         GStreamerMediaStream::create_video()
     }
 
-    fn create_stream_output(&self) -> Box<MediaOutput> {
+    fn create_stream_output(&self) -> Box<dyn MediaOutput> {
         Box::new(media_stream::MediaSink::new())
     }
 
@@ -163,7 +163,7 @@ impl Backend for GStreamerBackend {
 
 impl AudioBackend for GStreamerBackend {
     type Sink = audio_sink::GStreamerAudioSink;
-    fn make_decoder() -> Box<AudioDecoder> {
+    fn make_decoder() -> Box<dyn AudioDecoder> {
         Box::new(audio_decoder::GStreamerAudioDecoder::new())
     }
     fn make_sink() -> Result<Self::Sink, AudioSinkError> {
@@ -175,7 +175,7 @@ impl WebRtcBackend for GStreamerBackend {
     type Controller = webrtc::GStreamerWebRtcController;
 
     fn construct_webrtc_controller(
-        signaller: Box<WebRtcSignaller>,
+        signaller: Box<dyn WebRtcSignaller>,
         thread: WebRtcController,
     ) -> Self::Controller {
         webrtc::construct(signaller, thread).expect("WebRTC creation failed")
@@ -183,7 +183,7 @@ impl WebRtcBackend for GStreamerBackend {
 }
 
 impl BackendInit for GStreamerBackend {
-    fn init() -> Box<Backend> {
+    fn init() -> Box<dyn Backend> {
         gst::init().unwrap();
         Box::new(GStreamerBackend {
             capture_mocking: AtomicBool::new(false),

--- a/backends/gstreamer/media_stream.rs
+++ b/backends/gstreamer/media_stream.rs
@@ -32,11 +32,11 @@ pub struct GStreamerMediaStream {
 }
 
 impl MediaStream for GStreamerMediaStream {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
-    fn as_mut_any(&mut self) -> &mut Any {
+    fn as_mut_any(&mut self) -> &mut dyn Any {
         self
     }
 
@@ -221,7 +221,7 @@ impl Drop for GStreamerMediaStream {
 }
 
 pub struct MediaSink {
-    streams: Vec<Arc<Mutex<MediaStream>>>,
+    streams: Vec<Arc<Mutex<dyn MediaStream>>>,
 }
 
 impl MediaSink {

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -299,7 +299,7 @@ macro_rules! player(
 pub struct GStreamerPlayer {
     inner: RefCell<Option<Arc<Mutex<PlayerInner>>>>,
     observer: Arc<Mutex<IpcSender<PlayerEvent>>>,
-    renderer: Option<Arc<Mutex<FrameRenderer>>>,
+    renderer: Option<Arc<Mutex<dyn FrameRenderer>>>,
     /// Indicates whether the setup was succesfully performed and
     /// we are ready to consume a/v data.
     is_ready: Arc<Once>,
@@ -313,8 +313,8 @@ impl GStreamerPlayer {
     pub fn new(
         stream_type: StreamType,
         observer: IpcSender<PlayerEvent>,
-        renderer: Option<Arc<Mutex<FrameRenderer>>>,
-        gl_context: Box<PlayerGLContext>,
+        renderer: Option<Arc<Mutex<dyn FrameRenderer>>>,
+        gl_context: Box<dyn PlayerGLContext>,
     ) -> GStreamerPlayer {
         Self {
             inner: RefCell::new(None),

--- a/backends/gstreamer/render-unix/lib.rs
+++ b/backends/gstreamer/render-unix/lib.rs
@@ -60,7 +60,7 @@ impl RenderUnix {
     ///
     /// * `context` - is the PlayerContext trait object from
     /// application.
-    pub fn new(context: Box<PlayerGLContext>) -> Option<RenderUnix> {
+    pub fn new(context: Box<dyn PlayerGLContext>) -> Option<RenderUnix> {
         // Check that we actually have the elements that we
         // need to make this work.
         if gst::ElementFactory::find("glsinkbin").is_none() {

--- a/backends/gstreamer/render.rs
+++ b/backends/gstreamer/render.rs
@@ -23,7 +23,7 @@ mod platform {
 
     use super::*;
 
-    pub fn create_render(gl_context: Box<PlayerGLContext>) -> Option<Render> {
+    pub fn create_render(gl_context: Box<dyn PlayerGLContext>) -> Option<Render> {
         Render::new(gl_context)
     }
 }
@@ -81,7 +81,7 @@ pub struct GStreamerRender {
 }
 
 impl GStreamerRender {
-    pub fn new(gl_context: Box<PlayerGLContext>) -> Self {
+    pub fn new(gl_context: Box<dyn PlayerGLContext>) -> Self {
         GStreamerRender {
             render: platform::create_render(gl_context),
         }

--- a/backends/gstreamer/webrtc.rs
+++ b/backends/gstreamer/webrtc.rs
@@ -37,7 +37,7 @@ pub struct GStreamerWebRtcController {
     /// A handle to the event loop abstraction surrounding the webrtc implementations,
     /// which lets gstreamer callbacks send events back to the event loop to run on this object
     thread: WebRtcThread,
-    signaller: Box<WebRtcSignaller>,
+    signaller: Box<dyn WebRtcSignaller>,
     /// All the streams that are actually connected to the webrtcbin (i.e., their presence has already
     /// been negotiated)
     streams: Vec<MediaStreamId>,
@@ -528,7 +528,7 @@ impl GStreamerWebRtcController {
 }
 
 pub fn construct(
-    signaller: Box<WebRtcSignaller>,
+    signaller: Box<dyn WebRtcSignaller>,
     thread: WebRtcThread,
 ) -> Result<GStreamerWebRtcController, WebrtcError> {
     let main_loop = glib::MainLoop::new(None, false);

--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -246,10 +246,10 @@ impl ui::Example for App {
 
     fn get_image_handlers(
         &self,
-        _gl: &gl::Gl,
+        _gl: &dyn gl::Gl,
     ) -> (
-        Option<Box<webrender::ExternalImageHandler>>,
-        Option<Box<webrender::OutputImageHandler>>,
+        Option<Box<dyn webrender::ExternalImageHandler>>,
+        Option<Box<dyn webrender::OutputImageHandler>>,
     ) {
         if !self.use_gl {
             (None, None)
@@ -263,7 +263,7 @@ impl ui::Example for App {
         }
     }
 
-    fn draw_custom(&self, _gl: &gl::Gl) {}
+    fn draw_custom(&self, _gl: &dyn gl::Gl) {}
 
     fn use_gl(&mut self, use_gl: bool) {
         self.use_gl = use_gl;

--- a/examples/player/player_wrapper.rs
+++ b/examples/player/player_wrapper.rs
@@ -23,8 +23,8 @@ pub struct PlayerWrapper {
 impl PlayerWrapper {
     pub fn new(
         path: &Path,
-        renderer: Option<Arc<Mutex<FrameRenderer>>>,
-        gl_context: Box<PlayerGLContext>,
+        renderer: Option<Arc<Mutex<dyn FrameRenderer>>>,
+        gl_context: Box<dyn PlayerGLContext>,
     ) -> Self {
         let (sender, receiver) = ipc::channel().unwrap();
         let servo_media = ServoMedia::get().unwrap();

--- a/examples/player/ui.rs
+++ b/examples/player/ui.rs
@@ -123,7 +123,7 @@ impl Notifier {
 }
 
 impl RenderNotifier for Notifier {
-    fn clone(&self) -> Box<RenderNotifier> {
+    fn clone(&self) -> Box<dyn RenderNotifier> {
         Box::new(Notifier {
             events_proxy: self.events_proxy.clone(),
         })
@@ -187,14 +187,14 @@ pub trait Example {
     }
     fn get_image_handlers(
         &self,
-        _gl: &gl::Gl,
+        _gl: &dyn gl::Gl,
     ) -> (
-        Option<Box<webrender::ExternalImageHandler>>,
-        Option<Box<webrender::OutputImageHandler>>,
+        Option<Box<dyn webrender::ExternalImageHandler>>,
+        Option<Box<dyn webrender::OutputImageHandler>>,
     ) {
         (None, None)
     }
-    fn draw_custom(&self, _gl: &gl::Gl) {}
+    fn draw_custom(&self, _gl: &dyn gl::Gl) {}
 
     fn use_gl(&mut self, _use_gl: bool) {}
 }
@@ -268,7 +268,7 @@ pub fn main_wrapper<E: Example + FrameRenderer>(
 
     let gl_context = Box::new(PlayerContextGlutin::new(use_gl, &windowed_context));
 
-    let example_: Option<Arc<Mutex<FrameRenderer>>> = if no_video {
+    let example_: Option<Arc<Mutex<dyn FrameRenderer>>> = if no_video {
         None
     } else {
         Some(example.clone())

--- a/examples/simple_webrtc.rs
+++ b/examples/simple_webrtc.rs
@@ -156,7 +156,7 @@ impl State {
 struct Signaller {
     sender: mpsc::Sender<OwnedMessage>,
     initiate_negotiation: bool,
-    output: Arc<Mutex<Box<MediaOutput>>>,
+    output: Arc<Mutex<Box<dyn MediaOutput>>>,
 }
 
 impl WebRtcSignaller for Signaller {
@@ -209,7 +209,7 @@ impl Signaller {
     fn new(
         sender: mpsc::Sender<OwnedMessage>,
         initiate_negotiation: bool,
-        output: Box<MediaOutput>,
+        output: Box<dyn MediaOutput>,
     ) -> Self {
         Signaller {
             sender,

--- a/player/frame.rs
+++ b/player/frame.rs
@@ -15,11 +15,11 @@ pub struct Frame {
     width: i32,
     height: i32,
     data: FrameData,
-    buffer: Arc<Buffer>,
+    buffer: Arc<dyn Buffer>,
 }
 
 impl Frame {
-    pub fn new(width: i32, height: i32, buffer: Arc<Buffer>) -> Result<Self, ()> {
+    pub fn new(width: i32, height: i32, buffer: Arc<dyn Buffer>) -> Result<Self, ()> {
         let data = buffer.to_vec()?;
 
         Ok(Frame {

--- a/servo-media/lib.rs
+++ b/servo-media/lib.rs
@@ -16,13 +16,13 @@ use streams::registry::MediaStreamId;
 use streams::MediaOutput;
 use webrtc::{WebRtcController, WebRtcSignaller};
 
-pub struct ServoMedia(Box<Backend>);
+pub struct ServoMedia(Box<dyn Backend>);
 
 static INITIALIZER: Once = sync::ONCE_INIT;
 static mut INSTANCE: *mut Mutex<Option<Arc<ServoMedia>>> = 0 as *mut _;
 
 pub trait BackendInit {
-    fn init() -> Box<Backend>;
+    fn init() -> Box<dyn Backend>;
 }
 
 pub trait Backend: Send + Sync {
@@ -30,16 +30,16 @@ pub trait Backend: Send + Sync {
         &self,
         stream_type: StreamType,
         sender: IpcSender<PlayerEvent>,
-        renderer: Option<Arc<Mutex<FrameRenderer>>>,
-        gl_context: Box<PlayerGLContext>,
-    ) -> Box<Player>;
+        renderer: Option<Arc<Mutex<dyn FrameRenderer>>>,
+        gl_context: Box<dyn PlayerGLContext>,
+    ) -> Box<dyn Player>;
     fn create_audiostream(&self) -> MediaStreamId;
     fn create_videostream(&self) -> MediaStreamId;
-    fn create_stream_output(&self) -> Box<MediaOutput>;
+    fn create_stream_output(&self) -> Box<dyn MediaOutput>;
     fn create_audioinput_stream(&self, set: MediaTrackConstraintSet) -> Option<MediaStreamId>;
     fn create_videoinput_stream(&self, set: MediaTrackConstraintSet) -> Option<MediaStreamId>;
     fn create_audio_context(&self, options: AudioContextOptions) -> AudioContext;
-    fn create_webrtc(&self, signaller: Box<WebRtcSignaller>) -> WebRtcController;
+    fn create_webrtc(&self, signaller: Box<dyn WebRtcSignaller>) -> WebRtcController;
     fn can_play_type(&self, media_type: &str) -> SupportsMediaType;
     fn set_capture_mocking(&self, _mock: bool) {}
 }
@@ -69,8 +69,8 @@ impl ServoMedia {
 }
 
 impl Deref for ServoMedia {
-    type Target = Backend + 'static;
-    fn deref(&self) -> &(Backend + 'static) {
+    type Target = dyn Backend + 'static;
+    fn deref(&self) -> &(dyn Backend + 'static) {
         &*self.0
     }
 }

--- a/streams/lib.rs
+++ b/streams/lib.rs
@@ -7,8 +7,8 @@ pub mod registry;
 use std::any::Any;
 
 pub trait MediaStream: Any + Send {
-    fn as_any(&self) -> &Any;
-    fn as_mut_any(&mut self) -> &mut Any;
+    fn as_any(&self) -> &dyn Any;
+    fn as_mut_any(&mut self) -> &mut dyn Any;
     fn set_id(&mut self, id: registry::MediaStreamId);
     fn ty(&self) -> MediaStreamType;
 }

--- a/streams/registry.rs
+++ b/streams/registry.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
 lazy_static! {
-    static ref MEDIA_STREAMS_REGISTRY: Mutex<HashMap<MediaStreamId, Arc<Mutex<MediaStream>>>> =
+    static ref MEDIA_STREAMS_REGISTRY: Mutex<HashMap<MediaStreamId, Arc<Mutex<dyn MediaStream>>>> =
         { Mutex::new(HashMap::new()) };
 }
 
@@ -20,7 +20,7 @@ impl MediaStreamId {
     }
 }
 
-pub fn register_stream(stream: Arc<Mutex<MediaStream>>) -> MediaStreamId {
+pub fn register_stream(stream: Arc<Mutex<dyn MediaStream>>) -> MediaStreamId {
     let id = MediaStreamId::new();
     stream.lock().unwrap().set_id(id.clone());
     MEDIA_STREAMS_REGISTRY
@@ -34,6 +34,6 @@ pub fn unregister_stream(stream: &MediaStreamId) {
     MEDIA_STREAMS_REGISTRY.lock().unwrap().remove(stream);
 }
 
-pub fn get_stream(stream: &MediaStreamId) -> Option<Arc<Mutex<MediaStream>>> {
+pub fn get_stream(stream: &MediaStreamId) -> Option<Arc<Mutex<dyn MediaStream>>> {
     MEDIA_STREAMS_REGISTRY.lock().unwrap().get(stream).cloned()
 }

--- a/webrtc/lib.rs
+++ b/webrtc/lib.rs
@@ -63,7 +63,7 @@ pub trait WebRtcBackend {
     type Controller: WebRtcControllerBackend + 'static;
 
     fn construct_webrtc_controller(
-        signaller: Box<WebRtcSignaller>,
+        signaller: Box<dyn WebRtcSignaller>,
         thread: WebRtcController,
     ) -> Self::Controller;
 }

--- a/webrtc/thread.rs
+++ b/webrtc/thread.rs
@@ -19,7 +19,7 @@ pub struct WebRtcController {
 }
 
 impl WebRtcController {
-    pub fn new<T: WebRtcBackend>(signaller: Box<WebRtcSignaller>) -> Self {
+    pub fn new<T: WebRtcBackend>(signaller: Box<dyn WebRtcSignaller>) -> Self {
         let (sender, receiver) = channel();
 
         let t = WebRtcController { sender };
@@ -107,7 +107,7 @@ pub enum InternalEvent {
     UpdateIceConnectionState,
 }
 
-pub fn handle_rtc_event(controller: &mut WebRtcControllerBackend, event: RtcThreadEvent) -> bool {
+pub fn handle_rtc_event(controller: &mut dyn WebRtcControllerBackend, event: RtcThreadEvent) -> bool {
     let result = match event {
         RtcThreadEvent::ConfigureStun(server, policy) => controller.configure(&server, policy),
         RtcThreadEvent::SetRemoteDescription(desc, cb) => {


### PR DESCRIPTION
Current nightly compiler shows as warning when a trait object is wrapped by Box, Arc or Mutex, which is recommended in the documentation. 

This patch add the clause to all reported cases.