### PR TITLE
Get rid of unsafe SDP media workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,7 +1999,6 @@ dependencies = [
  "gstreamer-base 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-player 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-sdp 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gstreamer-sdp-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-video 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-webrtc 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -29,10 +29,6 @@ version = "0.9"
 version = "0.8"
 features = ["v1_8"]
 
-[dependencies.gstreamer-sdp-sys]
-version = "0.8"
-features = ["v1_8"]
-
 [dependencies.gstreamer]
 version = "0.14"
 features = ["subclassing"]

--- a/backends/gstreamer/webrtc.rs
+++ b/backends/gstreamer/webrtc.rs
@@ -305,27 +305,12 @@ impl GStreamerWebRtcController {
     }
 
     fn store_remote_mline_info(&mut self, sdp: &gst_sdp::SDPMessage) {
-        // remove after https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/issues/189 is fixed
-        fn get_media(msg: &gst_sdp::SDPMessage, idx: u32) -> Option<gst_sdp::SDPMedia> {
-            extern crate gstreamer_sdp_sys as gst_sdp_sys;
-            use glib::translate::*;
-            unsafe {
-                from_glib_none(gst_sdp_sys::gst_sdp_message_get_media(
-                    msg.to_glib_none().0,
-                    idx,
-                ))
-            }
-        }
         self.pending_remote_mline_info.clear();
-        for i in 0..sdp.medias_len() {
+        for media in sdp.medias() {
             let mut caps = gst::Caps::new_empty();
             let caps_mut = caps.get_mut().expect("Fresh caps should be uniquely owned");
-            let media = get_media(&sdp, i).expect("Gstreamer reported incorrect medias_len()");
-            for format in 0..media.formats_len() {
-                let pt = media
-                    .get_format(format)
-                    .expect("Gstreamer reported incorrect formats_len()")
-                    .parse()
+            for format in media.formats() {
+                let pt = format.parse()
                     .expect("Gstreamer provided noninteger format");
                 caps_mut.append(
                     media


### PR DESCRIPTION
Upstream had [a bug](https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/issues/189) which we worked around in https://github.com/servo/media/pull/213 by directly accessing the underlying GObject data. This is no longer necessary after the gstreamer update, pulling in https://github.com/servo/media/pull/213

r? @sdroege @ferjm