### PR TITLE
Support initializing backend separately from media stack.

### DIFF
--- a/servo-media/lib.rs
+++ b/servo-media/lib.rs
@@ -75,6 +75,13 @@ impl ServoMedia {
         })
     }
 
+    pub fn init_with_backend(backend: Box<Backend>) {
+        INITIALIZER.call_once(|| unsafe {
+            let instance = Arc::new(ServoMedia(backend));
+            INSTANCE = Box::into_raw(Box::new(Mutex::new(Some(instance))));
+        })
+    }
+
     pub fn get() -> Result<Arc<ServoMedia>, ()> {
         let instance = unsafe { &*INSTANCE }.lock().unwrap();
         match *instance {


### PR DESCRIPTION
This is necessary to support initializing GStreamer with the correct plugins in binary distributions for consumers that don't already have GStreamer installed.