### PR TITLE
Remove shutdown_player and shutdown_audio_context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ members = [
   "streams",
   "webrtc"
 ]
-license = "MPL-2.0"
+

--- a/audio/context.rs
+++ b/audio/context.rs
@@ -3,7 +3,7 @@ use graph::{AudioGraph, InputPort, NodeId, OutputPort, PortId};
 use node::{AudioNodeInit, AudioNodeMessage, ChannelInfo};
 use render_thread::AudioRenderThread;
 use render_thread::AudioRenderThreadMsg;
-use servo_media_traits::{BackendMsg, ClientContextId, MediaInstance, Muteable};
+use servo_media_traits::{BackendMsg, ClientContextId, MediaInstance};
 use sink::AudioSink;
 use std::cell::Cell;
 use std::sync::mpsc::{self, Sender};
@@ -308,15 +308,13 @@ impl Drop for AudioContext {
     }
 }
 
-impl Muteable for AudioContext {
-    fn mute(&self, val: bool) -> Result<(), ()> {
-        self.set_mute(val);
-        Ok(())
-    }
-}
-
 impl MediaInstance for AudioContext {
     fn get_id(&self) -> usize {
         self.id
+    }
+
+    fn mute(&self, val: bool) -> Result<(), ()> {
+        self.set_mute(val);
+        Ok(())
     }
 }

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -21,7 +21,7 @@ use servo_media_player::{frame, Player, PlayerError, PlayerEvent, StreamType};
 use servo_media_streams::capture::MediaTrackConstraintSet;
 use servo_media_streams::registry::{register_stream, unregister_stream, MediaStreamId};
 use servo_media_streams::{MediaOutput, MediaStream, MediaStreamType};
-use servo_media_traits::{ClientContextId, MediaInstance, Muteable};
+use servo_media_traits::{ClientContextId, MediaInstance};
 use servo_media_webrtc::{
     thread, BundlePolicy, IceCandidate, SessionDescription, WebRtcBackend, WebRtcController,
     WebRtcControllerBackend, WebRtcSignaller, WebrtcResult,
@@ -267,14 +267,12 @@ impl WebRtcControllerBackend for DummyWebRtcController {
     fn quit(&mut self) {}
 }
 
-impl Muteable for DummyPlayer {
-    fn mute(&self, _val: bool) -> Result<(), ()> {
-        Ok(())
-    }
-}
-
 impl MediaInstance for DummyPlayer {
     fn get_id(&self) -> usize {
         0
+    }
+
+    fn mute(&self, _val: bool) -> Result<(), ()> {
+        Ok(())
     }
 }

--- a/backends/gstreamer/lib.rs
+++ b/backends/gstreamer/lib.rs
@@ -61,12 +61,14 @@ use servo_media_player::{Player, PlayerEvent, StreamType};
 use servo_media_streams::capture::MediaTrackConstraintSet;
 use servo_media_streams::registry::MediaStreamId;
 use servo_media_streams::MediaOutput;
-use servo_media_traits::{ClientContextId, Muteable};
+use servo_media_traits::{BackendMsg, ClientContextId, Muteable};
 use servo_media_webrtc::{WebRtcBackend, WebRtcController, WebRtcSignaller};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex, Weak};
+use std::thread;
 use std::vec::Vec;
 
 lazy_static! {
@@ -75,8 +77,10 @@ lazy_static! {
 
 pub struct GStreamerBackend {
     capture_mocking: AtomicBool,
-    muteables: Mutex<HashMap<ClientContextId, Vec<(usize, Weak<Mutex<dyn Muteable>>)>>>,
+    muteables: Arc<Mutex<HashMap<ClientContextId, Vec<(usize, Weak<Mutex<dyn Muteable>>)>>>>,
     next_muteable_id: AtomicUsize,
+    /// Channel to communicate media instances with its owner Backend.
+    backend_chan: Arc<Mutex<Sender<BackendMsg>>>,
 }
 
 #[derive(Debug)]
@@ -106,78 +110,78 @@ impl GStreamerBackend {
             return Err(ErrorLoadingPlugins(errors));
         }
 
+        let muteables: Arc<
+            Mutex<HashMap<ClientContextId, Vec<(usize, Weak<Mutex<dyn Muteable>>)>>>,
+        > = Arc::new(Mutex::new(HashMap::new()));
+
+        let muteables_ = muteables.clone();
+        let (backend_chan, recvr) = mpsc::channel();
+        thread::Builder::new()
+            .name("GStreamerBackend ShutdownThread".to_owned())
+            .spawn(move || {
+                match recvr.recv().unwrap() {
+                    BackendMsg::Shutdown(context_id, muteable_id) => {
+                        if let Some(vec) = muteables_.lock().unwrap().get_mut(&context_id) {
+                            vec.retain(|m| m.0 != muteable_id);
+                            if vec.is_empty() {
+                                muteables_.lock().unwrap().remove(&context_id);
+                            }
+                        }
+                    }
+                };
+            })
+            .unwrap();
+
         Ok(Box::new(GStreamerBackend {
             capture_mocking: AtomicBool::new(false),
-            muteables: Mutex::new(HashMap::new()),
+            muteables,
             next_muteable_id: AtomicUsize::new(0),
+            backend_chan: Arc::new(Mutex::new(backend_chan)),
         }))
-    }
-
-    fn remove_muteable(&self, id: &ClientContextId, muteable_id: usize) {
-        let mut muteables = self.muteables.lock().unwrap();
-        if let Some(vec) = muteables.get_mut(&id) {
-            vec.retain(|m| m.0 != muteable_id);
-            if vec.len() == 0 {
-                muteables.remove(&id);
-            }
-        }
     }
 }
 
 impl Backend for GStreamerBackend {
     fn create_player(
         &self,
-        id: &ClientContextId,
+        context_id: &ClientContextId,
         stream_type: StreamType,
         sender: IpcSender<PlayerEvent>,
         renderer: Option<Arc<Mutex<dyn FrameRenderer>>>,
         gl_context: Box<dyn PlayerGLContext>,
     ) -> Arc<Mutex<dyn Player>> {
-        let muteable_id = self.next_muteable_id.fetch_add(1, Ordering::Relaxed);
+        let id = self.next_muteable_id.fetch_add(1, Ordering::Relaxed);
         let player = Arc::new(Mutex::new(player::GStreamerPlayer::new(
-            muteable_id,
+            id,
+            context_id,
+            self.backend_chan.clone(),
             stream_type,
             sender,
             renderer,
             gl_context,
         )));
         let mut muteables = self.muteables.lock().unwrap();
-        let entry = muteables.entry(*id).or_insert(Vec::new());
-        entry.push((muteable_id, Arc::downgrade(&player).clone()));
+        let entry = muteables.entry(*context_id).or_insert(Vec::new());
+        entry.push((id, Arc::downgrade(&player).clone()));
         player
-    }
-
-    fn shutdown_player(&self, id: &ClientContextId, player: Arc<Mutex<dyn Player>>) {
-        let player = player.lock().unwrap();
-        let p_id = player.get_id();
-        self.remove_muteable(id, p_id);
-
-        if let Err(e) = player.shutdown() {
-            warn!("Player was shut down with err: {:?}", e);
-        }
     }
 
     fn create_audio_context(
         &self,
-        id: &ClientContextId,
+        client_context_id: &ClientContextId,
         options: AudioContextOptions,
     ) -> Arc<Mutex<AudioContext>> {
-        let muteable_id = self.next_muteable_id.fetch_add(1, Ordering::Relaxed);
-        let context = Arc::new(Mutex::new(AudioContext::new::<Self>(muteable_id, options)));
+        let id = self.next_muteable_id.fetch_add(1, Ordering::Relaxed);
+        let context = Arc::new(Mutex::new(AudioContext::new::<Self>(
+            id,
+            client_context_id,
+            self.backend_chan.clone(),
+            options,
+        )));
         let mut muteables = self.muteables.lock().unwrap();
-        let entry = muteables.entry(*id).or_insert(Vec::new());
-        entry.push((muteable_id, Arc::downgrade(&context).clone()));
+        let entry = muteables.entry(*client_context_id).or_insert(Vec::new());
+        entry.push((id, Arc::downgrade(&context).clone()));
         context
-    }
-
-    fn shutdown_audio_context(
-        &self,
-        id: &ClientContextId,
-        audio_context: Arc<Mutex<AudioContext>>,
-    ) {
-        let audio_context = audio_context.lock().unwrap();
-        let ac_id = audio_context.get_id();
-        self.remove_muteable(id, ac_id);
     }
 
     fn create_webrtc(&self, signaller: Box<dyn WebRtcSignaller>) -> WebRtcController {

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -17,7 +17,7 @@ use servo_media_player::{
     PlaybackState, Player, PlayerError, PlayerEvent, SeekLock, SeekLockMsg, StreamType,
 };
 use servo_media_streams::registry::{get_stream, MediaStreamId};
-use servo_media_traits::{BackendMsg, ClientContextId, MediaInstance, Muteable};
+use servo_media_traits::{BackendMsg, ClientContextId, MediaInstance};
 use source::{register_servo_src, ServoSrc};
 use std::cell::RefCell;
 use std::error::Error;
@@ -787,15 +787,13 @@ impl Player for GStreamerPlayer {
     }
 }
 
-impl Muteable for GStreamerPlayer {
-    fn mute(&self, val: bool) -> Result<(), ()> {
-        self.set_mute(val).map_err(|_| ())
-    }
-}
-
 impl MediaInstance for GStreamerPlayer {
     fn get_id(&self) -> usize {
         self.id
+    }
+
+    fn mute(&self, val: bool) -> Result<(), ()> {
+        self.set_mute(val).map_err(|_| ())
     }
 }
 

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -17,13 +17,13 @@ use servo_media_player::{
     PlaybackState, Player, PlayerError, PlayerEvent, SeekLock, SeekLockMsg, StreamType,
 };
 use servo_media_streams::registry::{get_stream, MediaStreamId};
-use servo_media_traits::Muteable;
+use servo_media_traits::{BackendMsg, ClientContextId, MediaInstance, Muteable};
 use source::{register_servo_src, ServoSrc};
 use std::cell::RefCell;
 use std::error::Error;
 use std::ops::Range;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc;
+use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex, Once};
 use std::time;
 use std::u64;
@@ -325,7 +325,12 @@ impl SeekChannel {
 }
 
 pub struct GStreamerPlayer {
+    /// The player unique ID.
     id: usize,
+    /// The ID of the client context this player belongs to.
+    context_id: ClientContextId,
+    /// Channel to communicate with the owner GStreamerBackend instance.
+    backend_chan: Arc<Mutex<Sender<BackendMsg>>>,
     inner: RefCell<Option<Arc<Mutex<PlayerInner>>>>,
     observer: Arc<Mutex<IpcSender<PlayerEvent>>>,
     renderer: Option<Arc<Mutex<dyn FrameRenderer>>>,
@@ -334,13 +339,15 @@ pub struct GStreamerPlayer {
     is_ready: Arc<Once>,
     /// Indicates whether the type of media stream to be played is a live stream.
     stream_type: StreamType,
-    /// Decorator used to setup the video sink and process the produced frames
+    /// Decorator used to setup the video sink and process the produced frames.
     render: Arc<Mutex<GStreamerRender>>,
 }
 
 impl GStreamerPlayer {
     pub fn new(
         id: usize,
+        context_id: &ClientContextId,
+        backend_chan: Arc<Mutex<Sender<BackendMsg>>>,
         stream_type: StreamType,
         observer: IpcSender<PlayerEvent>,
         renderer: Option<Arc<Mutex<dyn FrameRenderer>>>,
@@ -353,7 +360,9 @@ impl GStreamerPlayer {
         );
 
         Self {
-            id: id,
+            id,
+            context_id: *context_id,
+            backend_chan,
             inner: RefCell::new(None),
             observer: Arc::new(Mutex::new(observer)),
             renderer,
@@ -766,10 +775,6 @@ impl Player for GStreamerPlayer {
     inner_player_proxy!(set_volume, value, f64);
     inner_player_proxy!(buffered, Vec<Range<f64>>);
 
-    fn shutdown(&self) -> Result<(), PlayerError> {
-        self.stop()
-    }
-
     fn render_use_gl(&self) -> bool {
         self.render.lock().unwrap().is_gl()
     }
@@ -783,11 +788,24 @@ impl Player for GStreamerPlayer {
 }
 
 impl Muteable for GStreamerPlayer {
+    fn mute(&self, val: bool) -> Result<(), ()> {
+        self.set_mute(val).map_err(|_| ())
+    }
+}
+
+impl MediaInstance for GStreamerPlayer {
     fn get_id(&self) -> usize {
         self.id
     }
+}
 
-    fn mute(&self, val: bool) -> Result<(), ()> {
-        self.set_mute(val).map_err(|_| ())
+impl Drop for GStreamerPlayer {
+    fn drop(&mut self) {
+        let _ = self.stop();
+        let _ = self
+            .backend_chan
+            .lock()
+            .unwrap()
+            .send(BackendMsg::Shutdown(self.context_id, self.id));
     }
 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ license = "MPL-2.0"
 
 [dependencies]
 euclid = { version = "0.19.0", optional = true }
-failure = { version = "0.1", opional = true }
+failure = { version = "0.1", optional = true }
 failure_derive = { version = "0.1", optional = true }
 gleam = { version = "0.6.8", optional = true }
 hyper = { version = "0.12", optional = true }

--- a/examples/muted_audiocontext.rs
+++ b/examples/muted_audiocontext.rs
@@ -40,7 +40,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
             Default::default(),
         );
         context.connect_ports(osc3.output(0), dest.input(0));
-        // thread::sleep(time::Duration::from_millis(3000));
 
         let _ = context.resume();
         context.message_node(
@@ -77,9 +76,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     println!("servo_media unmuting s1");
     servo_media.mute(&context_id1, false);
     thread::sleep(time::Duration::from_millis(2000));
-
-    servo_media.shutdown_audio_context(&context_id1, context1);
-    servo_media.shutdown_audio_context(&context_id2, context2);
 }
 
 fn main() {

--- a/examples/muted_player.rs
+++ b/examples/muted_player.rs
@@ -123,8 +123,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
             PlayerEvent::EnoughData => println!("\nEnoughData"),
         }
     }
-
-    servo_media.shutdown_player(&context_id, player);
 }
 
 fn main() {

--- a/examples/play_media_stream.rs
+++ b/examples/play_media_stream.rs
@@ -78,7 +78,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
             }
         }
     }
-    player.lock().unwrap().shutdown().unwrap();
 }
 
 fn main() {

--- a/examples/player/app.rs
+++ b/examples/player/app.rs
@@ -107,7 +107,6 @@ pub struct App {
     player: Arc<Mutex<dyn player::Player>>,
     file: File,
     player_event_receiver: IpcReceiver<player::PlayerEvent>,
-    client_context_id: servo_media::ClientContextId,
     frame_renderer: Option<Arc<Mutex<MediaFrameRenderer>>>,
 }
 
@@ -215,14 +214,6 @@ impl App {
     }
 
     fn into_context(self) -> glutin::WindowedContext<glutin::PossiblyCurrent> {
-        let client_context_id = self.client_context_id;
-        let player = self.player;
-
-        let _ = ServoMedia::get().and_then(|media| {
-            media.shutdown_player(&client_context_id, player);
-            Ok(())
-        });
-
         self.webrender.deinit();
         self.windowed_context
     }

--- a/examples/player/app.rs
+++ b/examples/player/app.rs
@@ -185,9 +185,8 @@ impl App {
             }
         };
 
-        let client_context_id = servo_media::ClientContextId::build(1, 1);
         let player = servo_media.create_player(
-            &client_context_id,
+            &servo_media::ClientContextId::build(1, 1),
             player::StreamType::Seekable,
             player_event_sender,
             renderer,
@@ -208,7 +207,6 @@ impl App {
             player,
             file,
             player_event_receiver,
-            client_context_id,
             frame_renderer,
         })
     }

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -155,8 +155,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
     shutdown.store(true, Ordering::Relaxed);
     let _ = t.join();
-
-    player.lock().unwrap().shutdown().unwrap();
 }
 
 fn main() {

--- a/examples/wave_shaper.rs
+++ b/examples/wave_shaper.rs
@@ -53,7 +53,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
         );
         thread::sleep(time::Duration::from_millis(2000));
     }
-    servo_media.shutdown_audio_context(&id, context)
 }
 
 fn main() {

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -99,8 +99,6 @@ pub trait Player: Send + Muteable {
     fn end_of_stream(&self) -> Result<(), PlayerError>;
     /// Get the list of time ranges in seconds that have been buffered.
     fn buffered(&self) -> Result<Vec<Range<f64>>, PlayerError>;
-    /// Shut the player down. Stops playback and free up resources.
-    fn shutdown(&self) -> Result<(), PlayerError>;
     /// Set the stream to be played by the player.
     /// Only a single stream of the same type (audio or video) can be set.
     /// Subsequent calls with a stream of the same type will override the previously

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -9,7 +9,7 @@ pub mod frame;
 pub mod metadata;
 
 use ipc_channel::ipc::{self, IpcSender};
-use servo_media_traits::Muteable;
+use servo_media_traits::MediaInstance;
 use std::ops::Range;
 use streams::registry::MediaStreamId;
 
@@ -86,7 +86,7 @@ pub enum StreamType {
     Seekable,
 }
 
-pub trait Player: Send + Muteable {
+pub trait Player: Send + MediaInstance {
     fn play(&self) -> Result<(), PlayerError>;
     fn pause(&self) -> Result<(), PlayerError>;
     fn stop(&self) -> Result<(), PlayerError>;

--- a/servo-media/lib.rs
+++ b/servo-media/lib.rs
@@ -37,7 +37,6 @@ pub trait Backend: Send + Sync {
         renderer: Option<Arc<Mutex<dyn FrameRenderer>>>,
         gl_context: Box<dyn PlayerGLContext>,
     ) -> Arc<Mutex<dyn Player>>;
-    fn shutdown_player(&self, id: &ClientContextId, player: Arc<Mutex<dyn Player>>);
     fn create_audiostream(&self) -> MediaStreamId;
     fn create_videostream(&self) -> MediaStreamId;
     fn create_stream_output(&self) -> Box<dyn MediaOutput>;
@@ -48,7 +47,6 @@ pub trait Backend: Send + Sync {
         id: &ClientContextId,
         options: AudioContextOptions,
     ) -> Arc<Mutex<AudioContext>>;
-    fn shutdown_audio_context(&self, id: &ClientContextId, audio_context: Arc<Mutex<AudioContext>>);
     fn create_webrtc(&self, signaller: Box<dyn WebRtcSignaller>) -> WebRtcController;
     fn can_play_type(&self, media_type: &str) -> SupportsMediaType;
     fn set_capture_mocking(&self, _mock: bool) {}

--- a/traits/lib.rs
+++ b/traits/lib.rs
@@ -15,7 +15,16 @@ impl ClientContextId {
     }
 }
 
-pub trait Muteable: Send {
+pub trait MediaInstance {
     fn get_id(&self) -> usize;
+}
+
+pub trait Muteable: Send + MediaInstance {
     fn mute(&self, val: bool) -> Result<(), ()>;
+}
+
+pub enum BackendMsg {
+    /// Message to notify about a media instance shutdown.
+    /// The given `usize` is the media instance ID.
+    Shutdown(ClientContextId, usize),
 }

--- a/traits/lib.rs
+++ b/traits/lib.rs
@@ -15,11 +15,8 @@ impl ClientContextId {
     }
 }
 
-pub trait MediaInstance {
+pub trait MediaInstance: Send {
     fn get_id(&self) -> usize;
-}
-
-pub trait Muteable: Send + MediaInstance {
     fn mute(&self, val: bool) -> Result<(), ()>;
 }
 


### PR DESCRIPTION
This is a cleaner approach that does not require consumers of the API to call any shutdown* method to ensure that the Muteables are removed appropriately.