### PR TITLE
Block seek

### DIFF
--- a/backends/gstreamer/source.rs
+++ b/backends/gstreamer/source.rs
@@ -8,6 +8,7 @@ use gst::subclass::prelude::*;
 use gst_app;
 use gst_base::prelude::*;
 use std::convert::TryFrom;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use url::Url;
 
@@ -49,6 +50,7 @@ mod imp {
         appsrc: gst_app::AppSrc,
         srcpad: gst::GhostPad,
         position: Mutex<Position>,
+        seeking: AtomicBool,
     }
 
     impl ServoSrc {
@@ -66,8 +68,13 @@ mod imp {
             } else {
                 pos.offset = offset;
                 gst_debug!(self.cat, obj: parent, "seeking to offset: {}", pos.offset);
+                self.seeking.store(true, Ordering::Relaxed);
                 true
             }
+        }
+
+        pub fn set_seek_done(&self) {
+            self.seeking.store(false, Ordering::Relaxed);
         }
 
         pub fn push_buffer<O: IsA<gst::Object>>(
@@ -75,6 +82,11 @@ mod imp {
             parent: &O,
             data: Vec<u8>,
         ) -> Result<gst::FlowSuccess, gst::FlowError> {
+            if self.seeking.load(Ordering::Relaxed) {
+                gst_debug!(self.cat, obj: parent, "seek in progress, ignored data");
+                return Ok(gst::FlowSuccess::Ok);
+            }
+
             let mut pos = self.position.lock().unwrap(); // will block seeking
 
             let length = u64::try_from(data.len()).unwrap();
@@ -134,6 +146,12 @@ mod imp {
                     let buffer = buffer.get_mut().unwrap();
                     buffer.set_offset(buffer_offset);
                     buffer.set_offset_end(buffer_offset_end);
+                }
+
+                if self.seeking.load(Ordering::Relaxed) {
+                    gst_trace!(self.cat, obj: parent, "stopping buffer appends due to seek");
+                    ret = Ok(gst::FlowSuccess::Ok);
+                    break;
                 }
 
                 gst_trace!(self.cat, obj: parent, "Pushing buffer {:?}", buffer);
@@ -232,6 +250,7 @@ mod imp {
                 appsrc: app_src,
                 srcpad: ghost_pad,
                 position: Mutex::new(Default::default()),
+                seeking: AtomicBool::new(false),
             }
         }
 
@@ -370,6 +389,10 @@ impl ServoSrc {
 
     pub fn set_seek_offset(&self, offset: u64) -> bool {
         imp::ServoSrc::from_instance(self).set_seek_offset(self, offset)
+    }
+
+    pub fn set_seek_done(&self) {
+        imp::ServoSrc::from_instance(self).set_seek_done();
     }
 
     pub fn push_buffer(&self, data: Vec<u8>) -> Result<gst::FlowSuccess, gst::FlowError> {

--- a/examples/muted_player.rs
+++ b/examples/muted_player.rs
@@ -117,7 +117,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
                     muted = false;
                 }
             }
-            PlayerEvent::SeekData(_) => {}
+            PlayerEvent::SeekData(_, _) => {}
             PlayerEvent::SeekDone(_) => {}
             PlayerEvent::NeedData => println!("\nNeedData"),
             PlayerEvent::EnoughData => println!("\nEnoughData"),

--- a/examples/play_media_stream.rs
+++ b/examples/play_media_stream.rs
@@ -66,7 +66,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
                 }
                 println!("Position changed {:?}", p)
             }
-            PlayerEvent::SeekData(_) => {
+            PlayerEvent::SeekData(_, _) => {
                 println!("\nERROR: Should not receive SeekData for streams")
             }
             PlayerEvent::SeekDone(_) => {

--- a/examples/player/app.rs
+++ b/examples/player/app.rs
@@ -71,6 +71,7 @@ enum PlayerCmd {
     Pause,
     Play,
     Seek(f64),
+    Mute,
     None,
 }
 
@@ -78,6 +79,7 @@ struct State {
     state: player::PlaybackState,
     pos: f64,
     duration: f64,
+    mute: bool,
 }
 
 impl Default for State {
@@ -86,6 +88,7 @@ impl Default for State {
             state: player::PlaybackState::Stopped,
             pos: 0.,
             duration: std::f64::NAN,
+            mute: false,
         }
     }
 }
@@ -311,6 +314,7 @@ pub fn main_loop(mut app: App) -> Result<glutin::WindowedContext<glutin::Possibl
                             _ => PlayerCmd::None,
                         };
                     }
+                    glutin::VirtualKeyCode::M => playercmd = PlayerCmd::Mute,
                     _ => (),
                 },
                 _ => (), //println!("glutin event: {:?}", event),
@@ -352,6 +356,14 @@ pub fn main_loop(mut app: App) -> Result<glutin::WindowedContext<glutin::Possibl
                     .unwrap()
                     .seek(time)
                     .map_err(|_| MiscError("Failed to seek"))?;
+            }
+            PlayerCmd::Mute => {
+                playerstate.mute = !playerstate.mute;
+                player
+                    .lock()
+                    .unwrap()
+                    .mute(playerstate.mute)
+                    .map_err(|_| MiscError("Failed to mute player"))?;
             }
             _ => (),
         }

--- a/examples/player/app.rs
+++ b/examples/player/app.rs
@@ -288,34 +288,34 @@ pub fn main_loop(mut app: App) -> Result<glutin::WindowedContext<glutin::Possibl
                     framebuffer_size =
                         webrender_api::DeviceIntSize::new(size.width as i32, size.height as i32);
                 }
-                _ => (),
+                glutin::WindowEvent::KeyboardInput {
+                    input:
+                        glutin::KeyboardInput {
+                            state: glutin::ElementState::Pressed,
+                            virtual_keycode: Some(key),
+                            ..
+                        },
+                    ..
+                } => match key {
+                    glutin::VirtualKeyCode::Escape | glutin::VirtualKeyCode::Q => {
+                        playercmd = PlayerCmd::Stop
+                    }
+                    glutin::VirtualKeyCode::Right => playercmd = PlayerCmd::Seek(10.),
+                    glutin::VirtualKeyCode::Left => playercmd = PlayerCmd::Seek(-10.),
+                    glutin::VirtualKeyCode::Space => {
+                        playercmd = match playerstate.state {
+                            player::PlaybackState::Paused => PlayerCmd::Play,
+                            player::PlaybackState::Playing | player::PlaybackState::Buffering => {
+                                PlayerCmd::Pause
+                            }
+                            _ => PlayerCmd::None,
+                        };
+                    }
+                    _ => (),
+                },
+                _ => (), //println!("glutin event: {:?}", event),
             },
-            glutin::Event::DeviceEvent {
-                event:
-                    glutin::DeviceEvent::Key(glutin::KeyboardInput {
-                        state: glutin::ElementState::Pressed,
-                        virtual_keycode: Some(key),
-                        ..
-                    }),
-                ..
-            } => match key {
-                glutin::VirtualKeyCode::Escape | glutin::VirtualKeyCode::Q => {
-                    playercmd = PlayerCmd::Stop
-                }
-                glutin::VirtualKeyCode::Right => playercmd = PlayerCmd::Seek(10.),
-                glutin::VirtualKeyCode::Left => playercmd = PlayerCmd::Seek(-10.),
-                glutin::VirtualKeyCode::Space => {
-                    playercmd = match playerstate.state {
-                        player::PlaybackState::Paused => PlayerCmd::Play,
-                        player::PlaybackState::Playing | player::PlaybackState::Buffering => {
-                            PlayerCmd::Pause
-                        }
-                        _ => PlayerCmd::None,
-                    };
-                }
-                _ => (),
-            },
-            _ => (), //println!("glutin event: {:?}", event),
+            _ => (), // not our window
         });
 
         match playercmd {

--- a/examples/player/app.rs
+++ b/examples/player/app.rs
@@ -389,9 +389,14 @@ pub fn main_loop(mut app: App) -> Result<glutin::WindowedContext<glutin::Possibl
                         _ => (),
                     }
                 }
-                player::PlayerEvent::SeekData(offset) => {
+                player::PlayerEvent::SeekData(offset, sender) => {
                     input_eos = false;
-                    buf_reader.seek(SeekFrom::Start(offset))?;
+                    let ret = if let Ok(pos) = buf_reader.seek(SeekFrom::Start(offset)) {
+                        offset == pos
+                    } else {
+                        false
+                    };
+                    sender.send(ret).unwrap();
                 }
                 player::PlayerEvent::NeedData => {
                     if !input_eos {

--- a/examples/player/app.rs
+++ b/examples/player/app.rs
@@ -263,7 +263,7 @@ pub fn main_loop(mut app: App) -> Result<glutin::WindowedContext<glutin::Possibl
 
     // file reader
     let mut buf_reader = BufReader::new(file);
-    let mut buffer = [0; 8192];
+    let mut buffer = [0; 16384];
 
     player
         .lock()

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -142,9 +142,10 @@ fn run_example(servo_media: Arc<ServoMedia>) {
                     }
                 }
             }
-            PlayerEvent::SeekData(p) => {
+            PlayerEvent::SeekData(p, sender) => {
                 println!("\nSeek requested to position {:?}", p);
                 seek_sender.send(p).unwrap();
+                sender.send(true).unwrap();
             }
             PlayerEvent::SeekDone(p) => println!("\nSeeked to {:?}", p),
             PlayerEvent::NeedData => println!("\nNeedData"),

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -8,6 +8,7 @@ pub mod context;
 pub mod frame;
 pub mod metadata;
 
+use ipc_channel::ipc::IpcSender;
 use servo_media_traits::Muteable;
 use std::ops::Range;
 use streams::registry::MediaStreamId;
@@ -53,8 +54,9 @@ pub enum PlayerEvent {
     PositionChanged(u64),
     /// The player needs the data to perform a seek to the given offset.
     /// The next push_data should get the buffers from the new offset.
+    /// The player will be blocked until the user sends, through the IPC sender,
     /// This event is only received for seekable stream types.
-    SeekData(u64),
+    SeekData(u64, IpcSender<bool>),
     /// The player has performed a seek to the given offset.
     SeekDone(u64),
     StateChanged(PlaybackState),


### PR DESCRIPTION
These pull request includes:

* Fix a bug in player test app to filter the key press from the window
* Duplicate the size of input buffers in the player test to reduce the buffering
* Mute/unmute the player test when 'm' is pressed
* Block the player until the application finish the seek task, this is important to avoid download element get lost
* Handle the requested offset in servo source (kind of a continuation of the player blocking at seek)

With these changes, at least theoretically, we could revert commit 56fe008