### PR TITLE
Updated player for setting audio and video tracks

### DIFF
--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -161,6 +161,8 @@ impl Player for DummyPlayer {
     fn render_use_gl(&self) -> bool {
         false
     }
+    fn set_audio_track(&self, _: i32, _: bool) -> Result<(), PlayerError> { Ok(()) }
+    fn set_video_track(&self, _: i32, _: bool) -> Result<(), PlayerError> { Ok(()) }
 }
 
 impl WebRtcBackend for DummyBackend {

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -285,6 +285,22 @@ impl PlayerInner {
         }
         Err(PlayerError::SetStreamFailed)
     }
+
+    fn set_audio_track(&mut self, stream_index: i32, enabled: bool) -> Result<(), PlayerError> {
+        self.player
+            .set_audio_track(stream_index)
+            .map_err(|_| PlayerError::SetTrackFailed)?;
+        self.player.set_audio_track_enabled(enabled);
+        Ok(())
+    }
+
+    fn set_video_track(&mut self, stream_index: i32,  enabled: bool) -> Result<(), PlayerError> {
+        self.player
+            .set_video_track(stream_index)
+            .map_err(|_| PlayerError::SetTrackFailed)?;
+        self.player.set_video_track_enabled(enabled);
+        Ok(())
+    }
 }
 
 macro_rules! notify(
@@ -784,6 +800,20 @@ impl Player for GStreamerPlayer {
         let inner = self.inner.borrow();
         let mut inner = inner.as_ref().unwrap().lock().unwrap();
         inner.set_stream(stream, only_stream)
+    }
+
+    fn set_audio_track(&self, stream_index: i32, enabled: bool) -> Result<(), PlayerError> {
+        self.setup()?;
+        let inner = self.inner.borrow();
+        let mut inner = inner.as_ref().unwrap().lock().unwrap();
+        inner.set_audio_track(stream_index, enabled)
+    }
+
+    fn set_video_track(&self, stream_index: i32, enabled: bool) -> Result<(), PlayerError> {
+        self.setup()?;
+        let inner = self.inner.borrow();
+        let mut inner = inner.as_ref().unwrap().lock().unwrap();
+        inner.set_video_track(stream_index, enabled)
     }
 }
 

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -38,6 +38,8 @@ pub enum PlayerError {
     /// Setting an audio or video stream failed.
     /// Possibly because the type of source is not PlayerSource::Stream.
     SetStreamFailed,
+    // Setting an audio or video track failed.
+    SetTrackFailed,
 }
 
 pub type SeekLockMsg = (bool, IpcSender<()>);
@@ -111,4 +113,6 @@ pub trait Player: Send + MediaInstance {
     fn set_stream(&self, stream: &MediaStreamId, only_stream: bool) -> Result<(), PlayerError>;
     /// If player's rendering draws using GL textures
     fn render_use_gl(&self) -> bool;
+    fn set_audio_track(&self, stream_index: i32, enabled: bool) -> Result<(), PlayerError>;
+    fn set_video_track(&self, stream_index: i32, enabled: bool) -> Result<(), PlayerError>;
 }


### PR DESCRIPTION
This pull request is for being able to set video and audio tracks and is part of Servo issue [22799](https://github.com/servo/servo/issues/22799). 

Servo should be able to set multiple audio tracks at one time but the work here only allows for one. If anyone has any advice on how to set multiple audio tracks that would be great! 