### PR TITLE
Expose methods to suspend and resume all media actions

### DIFF
--- a/audio/buffer_source_node.rs
+++ b/audio/buffer_source_node.rs
@@ -127,9 +127,7 @@ impl AudioBufferSourceNode {
             AudioBufferSourceNodeMessage::SetLoopEnabled(loop_enabled) => {
                 self.loop_enabled = loop_enabled
             }
-            AudioBufferSourceNodeMessage::SetLoopEnd(loop_end) => {
-                self.loop_end = Some(loop_end)
-            }
+            AudioBufferSourceNodeMessage::SetLoopEnd(loop_end) => self.loop_end = Some(loop_end),
             AudioBufferSourceNodeMessage::SetLoopStart(loop_start) => {
                 self.loop_start = Some(loop_start)
             }

--- a/audio/context.rs
+++ b/audio/context.rs
@@ -317,4 +317,9 @@ impl MediaInstance for AudioContext {
         self.set_mute(val);
         Ok(())
     }
+
+    fn suspend(&self) -> Result<(), ()> {
+        let (tx, _) = mpsc::channel();
+        self.sender.send(AudioRenderThreadMsg::Suspend(tx)).map_err(|_| ())
+    }
 }

--- a/audio/context.rs
+++ b/audio/context.rs
@@ -320,11 +320,15 @@ impl MediaInstance for AudioContext {
 
     fn suspend(&self) -> Result<(), ()> {
         let (tx, _) = mpsc::channel();
-        self.sender.send(AudioRenderThreadMsg::Suspend(tx)).map_err(|_| ())
+        self.sender
+            .send(AudioRenderThreadMsg::Suspend(tx))
+            .map_err(|_| ())
     }
 
     fn resume(&self) -> Result<(), ()> {
         let (tx, _) = mpsc::channel();
-        self.sender.send(AudioRenderThreadMsg::Resume(tx)).map_err(|_| ())
+        self.sender
+            .send(AudioRenderThreadMsg::Resume(tx))
+            .map_err(|_| ())
     }
 }

--- a/audio/context.rs
+++ b/audio/context.rs
@@ -322,4 +322,9 @@ impl MediaInstance for AudioContext {
         let (tx, _) = mpsc::channel();
         self.sender.send(AudioRenderThreadMsg::Suspend(tx)).map_err(|_| ())
     }
+
+    fn resume(&self) -> Result<(), ()> {
+        let (tx, _) = mpsc::channel();
+        self.sender.send(AudioRenderThreadMsg::Resume(tx)).map_err(|_| ())
+    }
 }

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -161,8 +161,12 @@ impl Player for DummyPlayer {
     fn render_use_gl(&self) -> bool {
         false
     }
-    fn set_audio_track(&self, _: i32, _: bool) -> Result<(), PlayerError> { Ok(()) }
-    fn set_video_track(&self, _: i32, _: bool) -> Result<(), PlayerError> { Ok(()) }
+    fn set_audio_track(&self, _: i32, _: bool) -> Result<(), PlayerError> {
+        Ok(())
+    }
+    fn set_video_track(&self, _: i32, _: bool) -> Result<(), PlayerError> {
+        Ok(())
+    }
 }
 
 impl WebRtcBackend for DummyBackend {

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -281,4 +281,8 @@ impl MediaInstance for DummyPlayer {
     fn suspend(&self) -> Result<(), ()> {
         Ok(())
     }
+
+    fn resume(&self) -> Result<(), ()> {
+        Ok(())
+    }
 }

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -277,4 +277,8 @@ impl MediaInstance for DummyPlayer {
     fn mute(&self, _val: bool) -> Result<(), ()> {
         Ok(())
     }
+
+    fn suspend(&self) -> Result<(), ()> {
+        Ok(())
+    }
 }

--- a/backends/gstreamer/lib.rs
+++ b/backends/gstreamer/lib.rs
@@ -293,6 +293,26 @@ impl Backend for GStreamerBackend {
             }
         }
     }
+
+    fn resume(&self, id: &ClientContextId) {
+        let mut instances = self.instances.lock().unwrap();
+        match instances.get_mut(id) {
+            Some(vec) => vec.retain(|(_, weak)| {
+                if let Some(mutex) = weak.upgrade() {
+                    let instance = mutex.lock().unwrap();
+                    if instance.resume().is_err() {
+                        warn!("Could not resume media instance");
+                    }
+                    true
+                } else {
+                    false
+                }
+            }),
+            None => {
+                warn!("Trying to resume an unknown client context");
+            }
+        }
+    }
 }
 
 impl AudioBackend for GStreamerBackend {

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -294,7 +294,7 @@ impl PlayerInner {
         Ok(())
     }
 
-    fn set_video_track(&mut self, stream_index: i32,  enabled: bool) -> Result<(), PlayerError> {
+    fn set_video_track(&mut self, stream_index: i32, enabled: bool) -> Result<(), PlayerError> {
         self.player
             .set_video_track(stream_index)
             .map_err(|_| PlayerError::SetTrackFailed)?;

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -825,6 +825,10 @@ impl MediaInstance for GStreamerPlayer {
     fn mute(&self, val: bool) -> Result<(), ()> {
         self.set_mute(val).map_err(|_| ())
     }
+
+    fn suspend(&self) -> Result<(), ()> {
+        self.pause().map_err(|_| ())
+    }
 }
 
 impl Drop for GStreamerPlayer {

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -829,6 +829,10 @@ impl MediaInstance for GStreamerPlayer {
     fn suspend(&self) -> Result<(), ()> {
         self.pause().map_err(|_| ())
     }
+
+    fn resume(&self) -> Result<(), ()> {
+        self.play().map_err(|_| ())
+    }
 }
 
 impl Drop for GStreamerPlayer {

--- a/examples/audio_decoder.rs
+++ b/examples/audio_decoder.rs
@@ -17,9 +17,10 @@ use std::{thread, time};
 fn run_example(servo_media: Arc<ServoMedia>) {
     let options = <RealTimeAudioContextOptions>::default();
     let sample_rate = options.sample_rate;
-    let context =
-        servo_media.create_audio_context(&ClientContextId::build(1, 1),
-                                         AudioContextOptions::RealTimeAudioContext(options));
+    let context = servo_media.create_audio_context(
+        &ClientContextId::build(1, 1),
+        AudioContextOptions::RealTimeAudioContext(options),
+    );
     let context = context.lock().unwrap();
     let args: Vec<_> = env::args().collect();
     let default = "./examples/resources/viper_cut.ogg";
@@ -73,7 +74,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     context.message_node(
         buffer_source,
         AudioNodeMessage::AudioBufferSourceNode(AudioBufferSourceNodeMessage::SetBuffer(Some(
-            AudioBuffer::from_buffers(decoded_audio.lock().unwrap().to_vec(), sample_rate)
+            AudioBuffer::from_buffers(decoded_audio.lock().unwrap().to_vec(), sample_rate),
         ))),
     );
     let _ = context.resume();

--- a/servo-media/lib.rs
+++ b/servo-media/lib.rs
@@ -56,6 +56,15 @@ pub trait Backend: Send + Sync {
     /// The client context identifier is currently an abstraction of Servo's BrowsingContextId.
     /// https://github.com/servo/servo/blob/d8d70f66b1cbd156e9ff979babb84a1c5b579886/components/msg/constellation_msg.rs#L145
     fn mute(&self, _id: &ClientContextId, _val: bool) {}
+    /// Allow suspending all AudioContexts and Players playback associated with the given client
+    /// context identifier.
+    /// Note that suspending does not involve releasing any resources, so media playback can
+    /// be restarted.
+    /// Backend implementations are responsible for keeping a match between client contexts and the AudioContexts
+    /// and Players created for these contexts.
+    /// The client context identifier is currently an abstraction of Servo's BrowsingContextId.
+    /// https://github.com/servo/servo/blob/d8d70f66b1cbd156e9ff979babb84a1c5b579886/components/msg/constellation_msg.rs#L145
+    fn suspend(&self, _id: &ClientContextId) {}
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/servo-media/lib.rs
+++ b/servo-media/lib.rs
@@ -50,21 +50,25 @@ pub trait Backend: Send + Sync {
     fn create_webrtc(&self, signaller: Box<dyn WebRtcSignaller>) -> WebRtcController;
     fn can_play_type(&self, media_type: &str) -> SupportsMediaType;
     fn set_capture_mocking(&self, _mock: bool) {}
-    /// Allow muting/unmuting all AudioContexts and Players associated with the given client context identifier.
-    /// Backend implementations are responsible for keeping a match between client contexts and the AudioContexts
-    /// and Players created for these contexts.
-    /// The client context identifier is currently an abstraction of Servo's BrowsingContextId.
-    /// https://github.com/servo/servo/blob/d8d70f66b1cbd156e9ff979babb84a1c5b579886/components/msg/constellation_msg.rs#L145
+    /// Allow muting/unmuting the media instances associated with the given client context identifier.
+    /// Backend implementations are responsible for keeping a match between client contexts
+    /// and the media instances created for these contexts.
+    /// The client context identifier is currently an abstraction of Servo's PipelineId.
     fn mute(&self, _id: &ClientContextId, _val: bool) {}
-    /// Allow suspending all AudioContexts and Players playback associated with the given client
+    /// Allow suspending the activity of all media instances associated with the given client
     /// context identifier.
     /// Note that suspending does not involve releasing any resources, so media playback can
     /// be restarted.
-    /// Backend implementations are responsible for keeping a match between client contexts and the AudioContexts
-    /// and Players created for these contexts.
-    /// The client context identifier is currently an abstraction of Servo's BrowsingContextId.
-    /// https://github.com/servo/servo/blob/d8d70f66b1cbd156e9ff979babb84a1c5b579886/components/msg/constellation_msg.rs#L145
+    /// Backend implementations are responsible for keeping a match between client contexts
+    /// and the media instances created for these contexts.
+    /// The client context identifier is currently an abstraction of Servo's PipelineId.
     fn suspend(&self, _id: &ClientContextId) {}
+    /// Allow resuming the activity of all the media instances associated with the given client
+    /// context identifier.
+    /// Backend implementations are responsible for keeping a match between client contexts
+    /// and the media instances created for these contexts.
+    /// The client context identifier is currently an abstraction of Servo's PipelineId.
+    fn resume(&self, _id: &ClientContextId) {}
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/traits/lib.rs
+++ b/traits/lib.rs
@@ -15,10 +15,13 @@ impl ClientContextId {
     }
 }
 
+/// Common functionality for all high level media instances
+/// These currently are WebAudio AudioContexts and Players.
 pub trait MediaInstance: Send {
     fn get_id(&self) -> usize;
     fn mute(&self, val: bool) -> Result<(), ()>;
     fn suspend(&self) -> Result<(), ()>;
+    fn resume(&self) -> Result<(), ()>;
 }
 
 pub enum BackendMsg {

--- a/traits/lib.rs
+++ b/traits/lib.rs
@@ -18,6 +18,7 @@ impl ClientContextId {
 pub trait MediaInstance: Send {
     fn get_id(&self) -> usize;
     fn mute(&self, val: bool) -> Result<(), ()>;
+    fn suspend(&self) -> Result<(), ()>;
 }
 
 pub enum BackendMsg {


### PR DESCRIPTION
This is required for fixing https://github.com/servo/servo/issues/22763 and https://github.com/servo/servo/issues/21989

ServoMedia shuts down AudioContexts and Players when these are dropped, but because Servo keeps a bfcache, DOM objects are not always released immediately after navigation. So we need a way to manually suspend playback.

A similar issue occurs with `getUserMedia`, where we keep input streams active after navigation. I'll fix it in a follow-up.