### PR TITLE
linear extrapolation of endpoint samples in AudioBufferSourceNode

### DIFF
--- a/audio/buffer_source_node.rs
+++ b/audio/buffer_source_node.rs
@@ -394,10 +394,18 @@ impl AudioBuffer {
 
         let prev = pos.floor() as usize;
         let offset = pos - pos.floor();
-        let next_sample = *self.buffers[chan as usize].get(prev + 1).unwrap_or(&0.0);
-
-        ((1. - offset) * (self.buffers[chan as usize][prev] as f64) + offset * (next_sample as f64))
-            as f32
+        match self.buffers[chan as usize].get(prev + 1) {
+            Some(next_sample) => {
+                ((1. - offset) * (self.buffers[chan as usize][prev] as f64)
+                    + offset * (*next_sample as f64)) as f32
+            }
+            _ => {
+                // linear extrapolation of two prev samples
+                ((1. + offset) * (self.buffers[chan as usize][prev] as f64)
+                    - offset * (self.buffers[chan as usize][prev - 1] as f64))
+                    as f32
+            }
+        }
     }
 
     pub fn data_chan_mut(&mut self, chan: u8) -> &mut [f32] {

--- a/audio/panner_node.rs
+++ b/audio/panner_node.rs
@@ -333,7 +333,7 @@ impl AudioNodeEngine for PannerNode {
                     let x = if mono {
                         (azimuth + 90.) / 180.
                     } else if azimuth <= 0. {
-                        (azimuth + 90. / 90.)
+                        (azimuth + 90.) / 90.
                     } else {
                         azimuth / 90.
                     };


### PR DESCRIPTION
issue #300 

running test https://github.com/servo/servo/blob/master/tests/wpt/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/buffer-resampling.html after this patch results in:
![test results](https://user-images.githubusercontent.com/1618874/73188805-79746f00-4134-11ea-9fca-47b0c5868685.png)
