### PR TITLE
added demuxer presence check for audio/x-wav media type

### DIFF
--- a/backends/gstreamer/registry_scanner.rs
+++ b/backends/gstreamer/registry_scanner.rs
@@ -176,7 +176,9 @@ impl GStreamerRegistryScanner {
             self.supported_mime_types.insert("application/x-mpegurl");
         }
 
-        if has_element_for_media_type(&demux_factories, "application/x-wav") {
+        if has_element_for_media_type(&demux_factories, "application/x-wav")
+            || has_element_for_media_type(&demux_factories, "audio/x-wav")
+        {
             self.supported_mime_types.insert("audio/wav");
             self.supported_mime_types.insert("audio/vnd.wav");
             self.supported_mime_types.insert("audio/x-wav");

--- a/backends/gstreamer/render/lib.rs
+++ b/backends/gstreamer/render/lib.rs
@@ -13,7 +13,6 @@
 //! pipeline, and handle the produced buffers.
 //!
 extern crate gstreamer as gst;
-extern crate gstreamer_video as gst_video;
 
 extern crate servo_media_player as sm_player;
 


### PR DESCRIPTION
also fixed unused-extern-crates warning

GStreamerRegistryScanner was checking if wav is supported by searching
gstreamer factories for application/x-wav caps, but some hosts report wav
mime as audio/x-wav.

issue: https://github.com/servo/servo/issues/26273