### PR TITLE
added AudioRenderThreadMsg::GetNodeType

### DIFF
--- a/audio/node.rs
+++ b/audio/node.rs
@@ -37,7 +37,7 @@ pub enum AudioNodeInit {
 }
 
 /// Type of AudioNodeEngine.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq)]
 pub enum AudioNodeType {
     /// Not a constructable node
     AudioListenerNode,


### PR DESCRIPTION
Some `AudioParams` for some nodes arent allowed to change automation rate
to `ARate`.
To check for this in servo in `SetAutomationRate` `AudioNodeType` must be
exposed via `AudioContext` method.

This is preliminary step to implement these checks in [SetAutomationRate](https://github.com/servo/servo/blob/3ea6d87bcc37167464e856949a4b9b77d0e9318a/components/script/dom/audioparam.rs#L108)