### PR TITLE
Add MediaStreamDestinationNode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,6 +2143,7 @@ dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-media-player 0.1.0",
+ "servo-media-streams 0.1.0",
  "servo-media-traits 0.1.0",
  "servo_media_derive 0.1.0",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/audio/Cargo.toml
+++ b/audio/Cargo.toml
@@ -17,6 +17,7 @@ serde = "1.0.66"
 servo_media_derive = { path = "../servo-media-derive" }
 servo-media-player = { path = "../player" }
 servo-media-traits = { path = "../traits" }
+servo-media-streams = { path = "../streams" }
 smallvec = "0.6.1"
 speexdsp-resampler = "0.1.0"
 num-complex = "0.2.4"

--- a/audio/lib.rs
+++ b/audio/lib.rs
@@ -17,6 +17,7 @@ extern crate smallvec;
 extern crate speexdsp_resampler;
 #[macro_use]
 pub mod macros;
+extern crate servo_media_streams;
 extern crate servo_media_traits;
 
 pub mod analyser_node;

--- a/audio/lib.rs
+++ b/audio/lib.rs
@@ -34,6 +34,7 @@ pub mod graph;
 pub mod iir_filter_node;
 pub mod listener;
 pub mod media_element_source_node;
+pub mod media_stream_destination_node;
 pub mod node;
 pub mod offline_sink;
 pub mod oscillator_node;

--- a/audio/media_stream_destination_node.rs
+++ b/audio/media_stream_destination_node.rs
@@ -1,0 +1,46 @@
+use block::Chunk;
+use node::{AudioNodeEngine, BlockInfo};
+use node::{AudioNodeType, ChannelInfo};
+use servo_media_streams::MediaStreamId;
+use sink::AudioSink;
+use std::sync::mpsc::Sender;
+
+#[derive(AudioNodeCommon)]
+pub(crate) struct MediaStreamDestinationNode {
+    channel_info: ChannelInfo,
+    sink: Box<dyn AudioSink + 'static>,
+}
+
+impl MediaStreamDestinationNode {
+    pub fn new(
+        tx: Sender<MediaStreamId>,
+        sample_rate: f32,
+        sink: Box<dyn AudioSink + 'static>,
+        channel_info: ChannelInfo,
+    ) -> Self {
+        let id = sink.init_stream(sample_rate).expect("init_stream failed");
+        sink.play().expect("Sink didn't start");
+        tx.send(id).expect("Sending media stream failed");
+        MediaStreamDestinationNode {
+            channel_info,
+            sink,
+        }
+    }
+}
+
+impl AudioNodeEngine for MediaStreamDestinationNode {
+    fn node_type(&self) -> AudioNodeType {
+        AudioNodeType::MediaStreamDestinationNode
+    }
+
+    fn process(&mut self, inputs: Chunk, _: &BlockInfo) -> Chunk {
+        self.sink
+            .push_data(inputs)
+            .expect("Pushing to stream failed");
+        Chunk::default()
+    }
+
+    fn output_count(&self) -> u32 {
+        0
+    }
+}

--- a/audio/media_stream_destination_node.rs
+++ b/audio/media_stream_destination_node.rs
@@ -18,7 +18,7 @@ impl MediaStreamDestinationNode {
         sink: Box<dyn AudioSink + 'static>,
         channel_info: ChannelInfo,
     ) -> Self {
-        let id = sink.init_stream(sample_rate).expect("init_stream failed");
+        let id = sink.init_stream(channel_info.count, sample_rate).expect("init_stream failed");
         sink.play().expect("Sink didn't start");
         tx.send(id).expect("Sending media stream failed");
         MediaStreamDestinationNode {

--- a/audio/node.rs
+++ b/audio/node.rs
@@ -10,6 +10,7 @@ use media_element_source_node::MediaElementSourceNodeMessage;
 use oscillator_node::{OscillatorNodeMessage, OscillatorNodeOptions};
 use panner_node::{PannerNodeMessage, PannerNodeOptions};
 use param::{Param, ParamRate, ParamType, UserAutomationEvent};
+use servo_media_streams::MediaStreamId;
 use std::sync::mpsc::Sender;
 use stereo_panner::StereoPannerOptions;
 use wave_shaper_node::{WaveShaperNodeMessage, WaveShaperNodeOptions};
@@ -29,6 +30,7 @@ pub enum AudioNodeInit {
     GainNode(GainNodeOptions),
     IIRFilterNode(IIRFilterNodeOptions),
     MediaElementSourceNode,
+    MediaStreamDestinationNode(Sender<MediaStreamId>),
     OscillatorNode(OscillatorNodeOptions),
     PannerNode(PannerNodeOptions),
     PeriodicWave,
@@ -56,6 +58,7 @@ pub enum AudioNodeType {
     GainNode,
     IIRFilterNode,
     MediaElementSourceNode,
+    MediaStreamDestinationNode,
     OscillatorNode,
     PannerNode,
     PeriodicWave,

--- a/audio/offline_sink.rs
+++ b/audio/offline_sink.rs
@@ -1,5 +1,6 @@
 use block::{Chunk, FRAMES_PER_BLOCK_USIZE};
 use render_thread::AudioRenderThreadMsg;
+use servo_media_streams::MediaStreamId;
 use sink::{AudioSink, AudioSinkError};
 use std::cell::{Cell, RefCell};
 use std::sync::mpsc::Sender;
@@ -38,7 +39,9 @@ impl AudioSink for OfflineAudioSink {
     fn init(&self, _: f32, _: Sender<AudioRenderThreadMsg>) -> Result<(), AudioSinkError> {
         Ok(())
     }
-
+    fn init_stream(&self, _: f32) -> Result<MediaStreamId, AudioSinkError> {
+        unreachable!("OfflineAudioSink should never be used for MediaStreamDestinationNode")
+    }
     fn play(&self) -> Result<(), AudioSinkError> {
         self.has_enough_data.set(false);
         Ok(())

--- a/audio/offline_sink.rs
+++ b/audio/offline_sink.rs
@@ -39,7 +39,7 @@ impl AudioSink for OfflineAudioSink {
     fn init(&self, _: f32, _: Sender<AudioRenderThreadMsg>) -> Result<(), AudioSinkError> {
         Ok(())
     }
-    fn init_stream(&self, _: f32) -> Result<MediaStreamId, AudioSinkError> {
+    fn init_stream(&self, _: u8, _: f32) -> Result<MediaStreamId, AudioSinkError> {
         unreachable!("OfflineAudioSink should never be used for MediaStreamDestinationNode")
     }
     fn play(&self) -> Result<(), AudioSinkError> {

--- a/audio/render_thread.rs
+++ b/audio/render_thread.rs
@@ -60,7 +60,7 @@ impl AudioSink for Sink {
         }
     }
 
-    fn init_stream(&self, _: f32) -> Result<MediaStreamId, AudioSinkError> {
+    fn init_stream(&self, _: u8, _: f32) -> Result<MediaStreamId, AudioSinkError> {
         unreachable!("Sink should never be used for MediaStreamDestinationNode")
     }
 

--- a/audio/render_thread.rs
+++ b/audio/render_thread.rs
@@ -14,6 +14,7 @@ use node::{BlockInfo, ChannelInfo};
 use offline_sink::OfflineAudioSink;
 use oscillator_node::OscillatorNode;
 use panner_node::PannerNode;
+use servo_media_streams::MediaStreamId;
 use sink::{AudioSink, AudioSinkError};
 use std::sync::mpsc::{Receiver, Sender};
 use stereo_panner::StereoPannerNode;
@@ -56,6 +57,10 @@ impl AudioSink for Sink {
             Sink::RealTime(ref sink) => sink.init(sample_rate, sender),
             Sink::Offline(ref sink) => Ok(sink.init(sample_rate, sender).unwrap()),
         }
+    }
+
+    fn init_stream(&self, _: f32) -> Result<MediaStreamId, AudioSinkError> {
+        unreachable!("Sink should never be used for MediaStreamDestinationNode")
     }
 
     fn play(&self) -> Result<(), AudioSinkError> {

--- a/audio/render_thread.rs
+++ b/audio/render_thread.rs
@@ -9,6 +9,7 @@ use gain_node::GainNode;
 use graph::{AudioGraph, InputPort, NodeId, OutputPort, PortId};
 use iir_filter_node::IIRFilterNode;
 use media_element_source_node::MediaElementSourceNode;
+use media_stream_destination_node::MediaStreamDestinationNode;
 use node::{AudioNodeEngine, AudioNodeInit, AudioNodeMessage};
 use node::{BlockInfo, ChannelInfo};
 use offline_sink::OfflineAudioSink;
@@ -195,6 +196,14 @@ impl AudioRenderThread {
             }
             AudioNodeInit::ConstantSourceNode(options) => {
                 Box::new(ConstantSourceNode::new(options, ch))
+            }
+            AudioNodeInit::MediaStreamDestinationNode(tx) => {
+                Box::new(MediaStreamDestinationNode::new(
+                    tx,
+                    self.sample_rate,
+                    (self.sink_factory)().unwrap(),
+                    ch
+                ))
             }
             AudioNodeInit::ChannelSplitterNode => Box::new(ChannelSplitterNode::new(ch)),
             AudioNodeInit::WaveShaperNode(options) => Box::new(WaveShaperNode::new(options, ch)),

--- a/audio/sink.rs
+++ b/audio/sink.rs
@@ -13,7 +13,7 @@ pub enum AudioSinkError {
     StateChangeFailed,
 }
 
-pub trait AudioSink {
+pub trait AudioSink: Send {
     fn init(
         &self,
         sample_rate: f32,

--- a/audio/sink.rs
+++ b/audio/sink.rs
@@ -19,7 +19,7 @@ pub trait AudioSink: Send {
         sample_rate: f32,
         render_thread_channel: Sender<AudioRenderThreadMsg>,
     ) -> Result<(), AudioSinkError>;
-    fn init_stream(&self, sample_rate: f32) -> Result<MediaStreamId, AudioSinkError>;
+    fn init_stream(&self, channels: u8, sample_rate: f32) -> Result<MediaStreamId, AudioSinkError>;
     fn play(&self) -> Result<(), AudioSinkError>;
     fn stop(&self) -> Result<(), AudioSinkError>;
     fn has_enough_data(&self) -> bool;

--- a/audio/sink.rs
+++ b/audio/sink.rs
@@ -1,5 +1,6 @@
 use block::Chunk;
 use render_thread::AudioRenderThreadMsg;
+use servo_media_streams::MediaStreamId;
 use std::sync::mpsc::Sender;
 
 #[derive(Debug, PartialEq)]
@@ -18,6 +19,7 @@ pub trait AudioSink {
         sample_rate: f32,
         render_thread_channel: Sender<AudioRenderThreadMsg>,
     ) -> Result<(), AudioSinkError>;
+    fn init_stream(&self, sample_rate: f32) -> Result<MediaStreamId, AudioSinkError>;
     fn play(&self) -> Result<(), AudioSinkError>;
     fn stop(&self) -> Result<(), AudioSinkError>;
     fn has_enough_data(&self) -> bool;

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -216,6 +216,11 @@ impl AudioSink for DummyAudioSink {
     fn init(&self, _: f32, _: Sender<AudioRenderThreadMsg>) -> Result<(), AudioSinkError> {
         Ok(())
     }
+    fn init_stream(&self, _: f32) -> Result<MediaStreamId, AudioSinkError> {
+        Ok(register_stream(Arc::new(Mutex::new(DummyMediaStream {
+            id: MediaStreamId::new(),
+        }))))
+    }
     fn play(&self) -> Result<(), AudioSinkError> {
         Ok(())
     }

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -216,7 +216,7 @@ impl AudioSink for DummyAudioSink {
     fn init(&self, _: f32, _: Sender<AudioRenderThreadMsg>) -> Result<(), AudioSinkError> {
         Ok(())
     }
-    fn init_stream(&self, _: f32) -> Result<MediaStreamId, AudioSinkError> {
+    fn init_stream(&self, _: u8, _: f32) -> Result<MediaStreamId, AudioSinkError> {
         Ok(register_stream(Arc::new(Mutex::new(DummyMediaStream {
             id: MediaStreamId::new(),
         }))))

--- a/backends/gstreamer/audio_sink.rs
+++ b/backends/gstreamer/audio_sink.rs
@@ -1,3 +1,4 @@
+use crate::media_stream::GStreamerMediaStream;
 use byte_slice_cast::*;
 use gst;
 use gst::prelude::*;
@@ -6,6 +7,7 @@ use gst_audio;
 use servo_media_audio::block::{Chunk, FRAMES_PER_BLOCK};
 use servo_media_audio::render_thread::AudioRenderThreadMsg;
 use servo_media_audio::sink::{AudioSink, AudioSinkError};
+use servo_media_streams::MediaStreamId;
 use std::cell::{Cell, RefCell};
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
@@ -108,6 +110,34 @@ impl AudioSink for GStreamerAudioSink {
             .map_err(|e| AudioSinkError::Backend(e.to_string()))?;
 
         Ok(())
+    }
+
+    fn init_stream(&self, sample_rate: f32) -> Result<MediaStreamId, AudioSinkError> {
+        self.sample_rate.set(sample_rate);
+        self.set_audio_info(sample_rate, 2)?;
+        self.appsrc.set_property_format(gst::Format::Time);
+
+        // Do not set max bytes or callback, we will push as needed
+
+        let appsrc = self.appsrc.as_ref().clone().upcast();
+        let convert = gst::ElementFactory::make("audioconvert", None)
+            .map_err(|_| AudioSinkError::Backend("audioconvert creation failed".to_owned()))?;
+        let proxy_src = gst::ElementFactory::make("proxysrc", None)
+            .map_err(|_| AudioSinkError::Backend("proxysrc creation failed".to_owned()))?;
+        let sink = gst::ElementFactory::make("proxysink", None)
+            .map_err(|_| AudioSinkError::Backend("proxysink creation failed".to_owned()))?;
+
+        proxy_src
+            .set_property("proxysink", &sink)
+            .map_err(|_| AudioSinkError::Backend("proxysink connection failed".to_owned()))?;
+
+        self.pipeline
+            .add_many(&[&appsrc, &convert, &sink])
+            .map_err(|e| AudioSinkError::Backend(e.to_string()))?;
+        gst::Element::link_many(&[&appsrc, &convert, &sink])
+            .map_err(|e| AudioSinkError::Backend(e.to_string()))?;
+
+        Ok(GStreamerMediaStream::create_audio_from(proxy_src))
     }
 
     fn play(&self) -> Result<(), AudioSinkError> {

--- a/backends/gstreamer/audio_sink.rs
+++ b/backends/gstreamer/audio_sink.rs
@@ -112,9 +112,9 @@ impl AudioSink for GStreamerAudioSink {
         Ok(())
     }
 
-    fn init_stream(&self, sample_rate: f32) -> Result<MediaStreamId, AudioSinkError> {
+    fn init_stream(&self, channels: u8, sample_rate: f32) -> Result<MediaStreamId, AudioSinkError> {
         self.sample_rate.set(sample_rate);
-        self.set_audio_info(sample_rate, 2)?;
+        self.set_audio_info(sample_rate, channels)?;
         self.appsrc.set_property_format(gst::Format::Time);
 
         // Do not set max bytes or callback, we will push as needed

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -807,23 +807,23 @@ impl GStreamerPlayer {
 }
 
 macro_rules! inner_player_proxy {
-    ($fn_name:ident, $return_type:ty) => (
+    ($fn_name:ident, $return_type:ty) => {
         fn $fn_name(&self) -> Result<$return_type, PlayerError> {
             self.setup()?;
             let inner = self.inner.borrow();
             let mut inner = inner.as_ref().unwrap().lock().unwrap();
             inner.$fn_name()
         }
-    );
+    };
 
-    ($fn_name:ident, $arg1:ident, $arg1_type:ty) => (
+    ($fn_name:ident, $arg1:ident, $arg1_type:ty) => {
         fn $fn_name(&self, $arg1: $arg1_type) -> Result<(), PlayerError> {
             self.setup()?;
             let inner = self.inner.borrow();
             let mut inner = inner.as_ref().unwrap().lock().unwrap();
             inner.$fn_name($arg1)
         }
-    )
+    };
 }
 
 impl Player for GStreamerPlayer {

--- a/backends/gstreamer/source.rs
+++ b/backends/gstreamer/source.rs
@@ -19,17 +19,17 @@ mod imp {
     use super::*;
 
     macro_rules! inner_appsrc_proxy {
-        ($fn_name:ident, $return_type:ty) => (
+        ($fn_name:ident, $return_type:ty) => {
             pub fn $fn_name(&self) -> $return_type {
                 self.appsrc.$fn_name()
             }
-        );
+        };
 
-        ($fn_name:ident, $arg1:ident, $arg1_type:ty, $return_type:ty) => (
+        ($fn_name:ident, $arg1:ident, $arg1_type:ty, $return_type:ty) => {
             pub fn $fn_name(&self, $arg1: $arg1_type) -> $return_type {
                 self.appsrc.$fn_name($arg1)
             }
-        )
+        };
     }
 
     #[derive(Debug)]
@@ -401,17 +401,17 @@ unsafe impl Send for ServoSrc {}
 unsafe impl Sync for ServoSrc {}
 
 macro_rules! inner_servosrc_proxy {
-    ($fn_name:ident, $return_type:ty) => (
+    ($fn_name:ident, $return_type:ty) => {
         pub fn $fn_name(&self) -> $return_type {
             imp::ServoSrc::from_instance(self).$fn_name()
         }
-    );
+    };
 
-    ($fn_name:ident, $arg1:ident, $arg1_type:ty, $return_type:ty) => (
+    ($fn_name:ident, $arg1:ident, $arg1_type:ty, $return_type:ty) => {
         pub fn $fn_name(&self, $arg1: $arg1_type) -> $return_type {
             imp::ServoSrc::from_instance(self).$fn_name($arg1)
         }
-    )
+    };
 }
 
 impl ServoSrc {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -96,6 +96,11 @@ name = "play_media_stream"
 path = "play_media_stream.rs"
 required-features = [ "player" ]
 
+
+[[bin]]
+name = "stream_dest_node"
+path = "stream_dest_node.rs"
+
 [[bin]]
 name = "simple_player"
 path = "simple_player.rs"

--- a/examples/stream_dest_node.rs
+++ b/examples/stream_dest_node.rs
@@ -1,0 +1,49 @@
+extern crate servo_media;
+extern crate servo_media_auto;
+
+use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage, AudioScheduledSourceNodeMessage};
+use servo_media::audio::oscillator_node::OscillatorNodeOptions;
+use servo_media::{ClientContextId, ServoMedia};
+use std::sync::Arc;
+use std::sync::mpsc;
+use std::{thread, time};
+
+fn run_example(servo_media: Arc<ServoMedia>) {
+    let context =
+        servo_media.create_audio_context(&ClientContextId::build(1, 1), Default::default());
+    let context = context.lock().unwrap();
+    let options = OscillatorNodeOptions::default();
+    let osc1 = context.create_node(
+        AudioNodeInit::OscillatorNode(options.clone()),
+        Default::default(),
+    );
+
+    let (tx, rx) = mpsc::channel();
+    let dest = context.create_node(
+        AudioNodeInit::MediaStreamDestinationNode(tx),
+        Default::default(),
+    );
+    context.connect_ports(osc1.output(0), dest.input(0));
+
+    let mut output = servo_media.create_stream_output();
+    output.add_stream(&rx.recv().unwrap());
+    let _ = context.resume();
+    context.message_node(
+        osc1,
+        AudioNodeMessage::AudioScheduledSourceNode(AudioScheduledSourceNodeMessage::Start(0.)),
+    );
+
+
+    thread::sleep(time::Duration::from_millis(3000));
+    let _ = context.close();
+    thread::sleep(time::Duration::from_millis(1000));
+}
+
+fn main() {
+    ServoMedia::init::<servo_media_auto::Backend>();
+    if let Ok(servo_media) = ServoMedia::get() {
+        run_example(servo_media);
+    } else {
+        unreachable!();
+    }
+}

--- a/streams/lib.rs
+++ b/streams/lib.rs
@@ -6,6 +6,8 @@ pub mod registry;
 
 use std::any::Any;
 
+pub use registry::*;
+
 pub trait MediaStream: Any + Send {
     fn as_any(&self) -> &dyn Any;
     fn as_mut_any(&mut self) -> &mut dyn Any;


### PR DESCRIPTION
One suboptimal part is that currently you need to block on a receiver to get the media stream id.

There are a couple better ways to do that:

 - Pass in the AudioSink from the client
 - Tweak the streams api to allow creating a media stream that has no input yet, and connect it up to

Fixes #342 

Thoughts?