### PR TITLE
Separate out encoding of media streams

### DIFF
--- a/backends/gstreamer/media_capture.rs
+++ b/backends/gstreamer/media_capture.rs
@@ -2,10 +2,9 @@ use crate::media_stream::GStreamerMediaStream;
 use gst;
 use gst::prelude::*;
 use servo_media_streams::capture::*;
-use servo_media_streams::registry::{register_stream, MediaStreamId};
+use servo_media_streams::registry::MediaStreamId;
 use servo_media_streams::MediaStreamType;
 use std::i32;
-use std::sync::{Arc, Mutex};
 
 trait AddToCaps {
     type Bound;
@@ -151,14 +150,14 @@ pub struct GstMediaTrack {
 fn create_input_stream(
     stream_type: MediaStreamType,
     constraint_set: MediaTrackConstraintSet,
-) -> Option<GStreamerMediaStream> {
+) -> Option<MediaStreamId> {
     let devices = GstMediaDevices::new();
     devices
         .get_track(stream_type == MediaStreamType::Video, constraint_set)
         .map(|track| {
             let f = match stream_type {
-                MediaStreamType::Audio => GStreamerMediaStream::create_audio_from_encoded,
-                MediaStreamType::Video => GStreamerMediaStream::create_video_from_encoded,
+                MediaStreamType::Audio => GStreamerMediaStream::create_audio_from,
+                MediaStreamType::Video => GStreamerMediaStream::create_video_from,
             };
             f(track.element)
         })
@@ -166,10 +165,8 @@ fn create_input_stream(
 
 pub fn create_audioinput_stream(constraint_set: MediaTrackConstraintSet) -> Option<MediaStreamId> {
     create_input_stream(MediaStreamType::Audio, constraint_set)
-        .map(|s| register_stream(Arc::new(Mutex::new(s))))
 }
 
 pub fn create_videoinput_stream(constraint_set: MediaTrackConstraintSet) -> Option<MediaStreamId> {
     create_input_stream(MediaStreamType::Video, constraint_set)
-        .map(|s| register_stream(Arc::new(Mutex::new(s))))
 }


### PR DESCRIPTION
This fixes https://github.com/servo/media/issues/354 by normalizing all streams to contain raw audio. Instead, webrtc is given a way to obtain an encoded adapter for a given media stream.

Fixes #354