### PR TITLE
refactor: address lints

### DIFF
--- a/backends/gstreamer/lib.rs
+++ b/backends/gstreamer/lib.rs
@@ -1,4 +1,3 @@
-#![feature(nll)]
 extern crate boxfnonce;
 extern crate byte_slice_cast;
 extern crate mime;

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -315,7 +315,7 @@ impl PlayerInner {
 
 macro_rules! notify(
     ($observer:expr, $event:expr) => {
-        $observer.lock().unwrap().send($event).unwrap();
+        $observer.lock().unwrap().send($event).unwrap()
     };
 );
 

--- a/player/video.rs
+++ b/player/video.rs
@@ -16,7 +16,7 @@ pub struct VideoFrame {
     width: i32,
     height: i32,
     data: VideoFrameData,
-    buffer: Arc<dyn Buffer>,
+    _buffer: Arc<dyn Buffer>,
 }
 
 impl VideoFrame {
@@ -27,7 +27,7 @@ impl VideoFrame {
             width,
             height,
             data,
-            buffer,
+            _buffer: buffer,
         })
     }
 

--- a/webrtc/lib.rs
+++ b/webrtc/lib.rs
@@ -41,12 +41,12 @@ pub trait WebRtcControllerBackend: Send {
     fn configure(&mut self, stun_server: &str, policy: BundlePolicy) -> WebRtcResult;
     fn set_remote_description(
         &mut self,
-        SessionDescription,
+        _: SessionDescription,
         cb: SendBoxFnOnce<'static, ()>,
     ) -> WebRtcResult;
     fn set_local_description(
         &mut self,
-        SessionDescription,
+        _: SessionDescription,
         cb: SendBoxFnOnce<'static, ()>,
     ) -> WebRtcResult;
     fn add_ice_candidate(&mut self, candidate: IceCandidate) -> WebRtcResult;


### PR DESCRIPTION
Addresses the following warn-by-default lints, which are reported by the current compiler:
- `stable_features` (feature `nll`)
- `semicolon_in_expressions_from_macros`
- `anonymous_parameters`
- `dead_code`