### PR TITLE
Upgrade GStreamer dependencies and switch to Rust 2021 edition

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-23.04]
+        os: [ubuntu-22.04]
         rust: [nightly]
         target: ["default"]
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-23.04]
         rust: [nightly]
         target: ["default"]
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,12 +38,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 
 [[package]]
-name = "anyhow"
-version = "1.0.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
 name = "app_units"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,7 +463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "rustc_version 0.4.0",
  "syn 1.0.109",
@@ -595,7 +589,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
  "synstructure",
@@ -724,7 +718,7 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 2.0.38",
 ]
@@ -783,9 +777,9 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "gio-sys"
-version = "0.17.10"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ccf87c30a12c469b6d958950f6a9c09f2be20b7773f7e70d20b867fdf2628c3"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -836,11 +830,11 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.17.10"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fad45ba8d4d2cea612b432717e834f48031cd8853c8aaf43b2c79fec8d144b"
+checksum = "1c316afb01ce8067c5eaab1fc4f2cd47dc21ce7b6296358605e2ffab23ccbd19"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -859,24 +853,23 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.17.10"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca5c79337338391f1ab8058d6698125034ce8ef31b72a442437fa6c8580de26"
+checksum = "f8da903822b136d42360518653fcf154455defc437d3e7a81475bf9a95ff1e47"
 dependencies = [
- "anyhow",
  "heck",
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.17.10"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80aa6ea7bba0baac79222204aa786a6293078c210abe69ef1336911d4bdc4f0"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
  "system-deps",
@@ -964,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.17.10"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd34c3317740a6358ec04572c1bcfd3ac0b5b6529275fae255b237b314bb8062"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
  "glib-sys",
  "libc",
@@ -975,22 +968,21 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.20.7"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a4150420d4aa1caf6fa15f0dba7a5007d4116380633bd1253acce206098fc9"
+checksum = "b369a1eb2f7db49920d3d590bd988c5fb56dbf2347e1efb60307fe953546ee5d"
 dependencies = [
- "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "futures-channel",
  "futures-core",
  "futures-util",
  "glib",
  "gstreamer-sys",
+ "itertools",
  "libc",
  "muldiv",
  "num-integer",
  "num-rational",
- "once_cell",
  "option-operations",
  "paste",
  "pretty-hex",
@@ -1000,11 +992,10 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-app"
-version = "0.20.7"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9a6d39222f708ba3a55f259261452daf4fc0d36693fe14126a630beb6461a8"
+checksum = "343376fe0a5b39e7e46fb0fed6a1ead4206ea34584c153130d0f20e51a480b80"
 dependencies = [
- "bitflags 1.3.2",
  "futures-core",
  "futures-sink",
  "glib",
@@ -1012,14 +1003,13 @@ dependencies = [
  "gstreamer-app-sys",
  "gstreamer-base",
  "libc",
- "once_cell",
 ]
 
 [[package]]
 name = "gstreamer-app-sys"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cb5375aa8c23012ec5fadde1a37b972e87680776772669d2628772867056e2"
+checksum = "aea07f07a3f17278e6998390ecaea127e476f0af0360c2d83d96e6d3a97fb75e"
 dependencies = [
  "glib-sys",
  "gstreamer-base-sys",
@@ -1030,25 +1020,23 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-audio"
-version = "0.20.7"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8448db43cee0270c6ca94e6771c92a4c3b14c51ac1e6605a5f2deef66f5516f1"
+checksum = "7ba605da8e756873456eebb35184d2c2f2b2ead7af18c5bfdc6c012d6cf8b6ee"
 dependencies = [
- "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "glib",
  "gstreamer",
  "gstreamer-audio-sys",
  "gstreamer-base",
  "libc",
- "once_cell",
 ]
 
 [[package]]
 name = "gstreamer-audio-sys"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4001b779e4707b32acd6ec0960e327b926369c1a34f7c41d477ac42b2670e8"
+checksum = "78bd94ae8b177377855b38c3d809c686526786cdb771e6d68510509634b955d1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1060,25 +1048,23 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base"
-version = "0.20.7"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0896c4acff303dd21d6a96a7ea4cc9339f7096230fe1433720c9f0bed203985"
+checksum = "0fe38a6d5c1e516ce3fd6069e972a540d315448ed69fdadad739e6c6c6eb2a01"
 dependencies = [
  "atomic_refcell",
- "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "glib",
  "gstreamer",
  "gstreamer-base-sys",
  "libc",
- "once_cell",
 ]
 
 [[package]]
 name = "gstreamer-base-sys"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26114ed96f6668380f5a1554128159e98e06c3a7a8460f216d7cd6dce28f928c"
+checksum = "f4ca701f9078fe115b29b24c80910b577f9cb5b039182f050dbadf5933594b64"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1089,25 +1075,23 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82b83d18ad1c4d890694b4bedde170c748462a11f51a68428671bc1bf93e71e"
+checksum = "5caa903b631a00d7748efc3906d9108678162c5e15b87f83868d95ee85951613"
 dependencies = [
- "bitflags 1.3.2",
  "glib",
  "gstreamer",
  "gstreamer-base",
  "gstreamer-gl-sys",
  "gstreamer-video",
  "libc",
- "once_cell",
 ]
 
 [[package]]
 name = "gstreamer-gl-egl"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec342886c7037cf18e07cf00aa5b60498ef5f9841aa36078a51f28d93970f93"
+checksum = "4b8d9d4a058cad68285413b333b73bc90b4478734d0d6ab8a413d60aec25ae29"
 dependencies = [
  "glib",
  "gstreamer",
@@ -1118,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-egl-sys"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f6f24c488311f09198e41826634e5e693149f10c9da1f6aa1be9e4e81e414e"
+checksum = "e99ebc3ea45884fb78713ec14996dbca01920e8bcc8744c835fa82f251caa812"
 dependencies = [
  "glib-sys",
  "gstreamer-gl-sys",
@@ -1130,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-sys"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08af9ae5ca5aa01c4875346bb7e61310b75a9afc3607b52a6b73470be93bbc7"
+checksum = "88ba5f511a1c0b4693b9f01b2d6b7dd7f1b5b476a16b8b25a89f4265e8108c34"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1145,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-wayland"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e8229f920f1703cdd5415ed2a8caaa9dab7794be1a190bd7e3a3d91549f417"
+checksum = "fec276a2f2d022d09f7655d7b0a4b92439a856261a077f770b02388a8556e7ff"
 dependencies = [
  "glib",
  "gstreamer",
@@ -1158,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-wayland-sys"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7812f3fd82eb23c3f7f564b4d5c3b175dcc1e1947a4dcb93dde9129d9197232f"
+checksum = "917b86f16faa53a34501252fff39f09290ba1796b73e6be07d23d97f484412a1"
 dependencies = [
  "glib-sys",
  "gstreamer-gl-sys",
@@ -1170,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-x11"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a82db426e6789bcb36e093100c97f8586f3a118bb7f268f36da9421044f646"
+checksum = "d7021b9e32c9d2c2830898cfdb60f8b1e7fea560b7cd3e221b9fad01a32af67d"
 dependencies = [
  "glib",
  "gstreamer",
@@ -1183,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-x11-sys"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27467cb653e78d5d4b0b275f45b2bce6520f5b8b6a241867ae98f3c56f23f1"
+checksum = "c49aef03c7b9e159b5f4c557efe4a597437ea6e5e10f934ae8b214386c6ebcdc"
 dependencies = [
  "glib-sys",
  "gstreamer-gl-sys",
@@ -1195,24 +1179,22 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-player"
-version = "0.20.5"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5e04059f117b82ca64c40901610ca9ac1734383437c9fb69afba26c9ebf5a3"
+checksum = "e68dc9772932f6133a9517742918b13ab5414db1f47e19daebc3027a1c3d20d2"
 dependencies = [
- "bitflags 1.3.2",
  "glib",
  "gstreamer",
  "gstreamer-player-sys",
  "gstreamer-video",
  "libc",
- "once_cell",
 ]
 
 [[package]]
 name = "gstreamer-player-sys"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15321aaaf3bb247b4af3e09456a62dc17f030515d6328377a34081d9ed5803c0"
+checksum = "f5ef4d00b43d0aa94e9a518e6ef4a4c504b4b855304a0a5f4ed1493d5e5ca66c"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1224,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sdp"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb57c03bfdbb0489bcab6e9b58a2c059e6089dcf660b424949dbe672af726bf"
+checksum = "87946f9c6fabb44a73fb0b3b3d611c7d4468f741dd8e4f9a3d54e1ab2a6a8b36"
 dependencies = [
  "glib",
  "gstreamer",
@@ -1235,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sdp-sys"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9ae71a2d53659f6da93a83ebe06de12c9e075604e012c45644499b24474e1a"
+checksum = "006e4bdf4618c70a2cb440ca4adf1a4140fc118b1b314684903a48f0ef5e1da1"
 dependencies = [
  "glib-sys",
  "gstreamer-sys",
@@ -1247,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56fe047adef7d47dbafa8bc1340fddb53c325e16574763063702fc94b5786d2"
+checksum = "f86bf9de67a6ab7af67ac11588f4939e984a936030437219f269fe969d79ad8c"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1259,11 +1241,10 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video"
-version = "0.20.7"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69a9554795d3791b8467a30b35ed40ef279aa41c857e6f414ffd6a182a20225"
+checksum = "01b4d3141362b3d44a684e697d2bc55fea73d023315449cda83f0f4324531d64"
 dependencies = [
- "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "futures-channel",
  "glib",
@@ -1271,14 +1252,13 @@ dependencies = [
  "gstreamer-base",
  "gstreamer-video-sys",
  "libc",
- "once_cell",
 ]
 
 [[package]]
 name = "gstreamer-video-sys"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ddb6112d438aac0004d2db6053a572f92b1c5e0e9d6ff6c71d9245f7f73e46"
+checksum = "09cdc36baab839921b05d2468524da649f373dccc5f966c75e564029dc135b1c"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1290,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-webrtc"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2550a5453b2afb9222a186a3cf2b56be3770f7c13fcac337a8cf79de323210f9"
+checksum = "fab74a123e998f79bba3e823844be7e813d0eaad4169718bfe1f6613992fd905"
 dependencies = [
  "glib",
  "gstreamer",
@@ -1303,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-webrtc-sys"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6feeb7a38db02ec4a0fb91e4e02da6c8448a7caa16b64128927b31e581e7bfa"
+checksum = "e32df9bf9d801e6f874de2476fd3dcf2a1ca9247e8979bd4de034a45fd399663"
 dependencies = [
  "glib-sys",
  "gstreamer-sdp-sys",
@@ -1413,6 +1393,15 @@ checksum = "7ab3a34c91b7e84a72643bd75d1bac3afd241f78f9859fe0b5e5b2a6a75732c2"
  "tempfile",
  "uuid",
  "windows",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1557,7 +1546,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632647502a8bfa82458c07134791fffa7a719f00427d1afd79c3cb6d4960a982"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -1809,7 +1798,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 2.0.38",
 ]
@@ -1911,7 +1900,7 @@ name = "peek-poke-derive"
 version = "0.2.1"
 source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#415b9ba32648667313f6f4ce7965752285bf0b26"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
  "synstructure",
@@ -1999,7 +1988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
  "version_check 0.9.4",
@@ -2011,7 +2000,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "version_check 0.9.4",
 ]
@@ -2027,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2055,7 +2044,7 @@ version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
 ]
 
 [[package]]
@@ -2291,7 +2280,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.19",
+ "semver 1.0.20",
 ]
 
 [[package]]
@@ -2397,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "semver-parser"
@@ -2431,7 +2420,7 @@ version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 2.0.38",
 ]
@@ -2628,7 +2617,7 @@ dependencies = [
 name = "servo_media_derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -2735,7 +2724,7 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "unicode-ident",
 ]
@@ -2746,7 +2735,7 @@ version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "unicode-ident",
 ]
@@ -2757,7 +2746,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
@@ -2819,7 +2808,7 @@ version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
- "proc-macro2 1.0.68",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 2.0.38",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "app_units"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,16 +63,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "array-init"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30bbe2f5e3d117f55bd8c7a1f9191e4a5deba9f15f595bbea4f670c59c765db"
-
-[[package]]
 name = "ascii"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d6dc922a2792b006573f60b2648076355daeae5ce9cb59507e5908c9625d31"
 
 [[package]]
 name = "autocfg"
@@ -141,9 +147,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "block"
@@ -201,6 +207,16 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8790cf1286da485c72cf5fc7aeba308438800036ec67d89425924c4807268c9"
+dependencies = [
+ "smallvec 1.10.0",
+ "target-lexicon",
+]
 
 [[package]]
 name = "cfg-if"
@@ -366,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.14",
@@ -451,30 +467,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
  "rustc_version 0.4.0",
  "syn 1.0.107",
-]
-
-[[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -514,23 +510,12 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -591,17 +576,17 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
  "syn 1.0.107",
  "synstructure",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fixedbitset"
@@ -720,8 +705,8 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
  "syn 1.0.107",
 ]
 
@@ -778,6 +763,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
+name = "gio-sys"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1d43b0d7968b48455244ecafe41192871257f5740aa6b095eb19db78e362a5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.9.3"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fb573a09841b6386ddf15fd4bc6655b4f5b106ca962f57ecaecde32a0061c0"
+checksum = "a7f1de7cbde31ea4f0a919453a2dcece5d54d5b70e08f8ad254dc4840f5f09b6"
 dependencies = [
  "bitflags 1.3.2",
  "futures-channel",
@@ -829,20 +827,40 @@ dependencies = [
  "futures-executor",
  "futures-task",
  "futures-util",
+ "gio-sys",
+ "glib-macros",
  "glib-sys",
  "gobject-sys",
- "lazy_static",
  "libc",
+ "memchr",
+ "once_cell",
+ "smallvec 1.10.0",
+ "thiserror",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.17.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7206c5c03851ef126ea1444990e81fdd6765fb799d5bc694e4897ca01bb97f"
+dependencies = [
+ "anyhow",
+ "heck",
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.9.1"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95856f3802f446c05feffa5e24859fe6a183a7cb849c8449afc35c86b1e316e2"
+checksum = "49f00ad0a1bf548e61adfff15d83430941d9e1bb620e334f779edd1c745680a5"
 dependencies = [
  "libc",
- "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
@@ -927,158 +945,174 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.9.1"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d1a804f62034eccf370006ccaef3708a71c31d561fee88564abe71177553d9"
+checksum = "15e75b0000a64632b2d8ca3cf856af9308e3a970844f6e9659bd197f026793d0"
 dependencies = [
  "glib-sys",
  "libc",
- "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
 name = "gstreamer"
-version = "0.15.7"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8664a114cd6ec16bece783d5eee59496919915b1f6884400ba4a953274a163"
+checksum = "4530401c89be6dc10d77ae1587b811cf455c97dce7abf594cb9164527c7da7fc"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "futures-channel",
  "futures-core",
  "futures-util",
  "glib",
- "glib-sys",
- "gobject-sys",
  "gstreamer-sys",
- "lazy_static",
  "libc",
  "muldiv",
+ "num-integer",
  "num-rational",
+ "once_cell",
+ "option-operations",
  "paste",
+ "pretty-hex",
+ "smallvec 1.10.0",
+ "thiserror",
 ]
 
 [[package]]
 name = "gstreamer-app"
-version = "0.15.6"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789784e8d42f5add1e1e965cf9f7e2d09e21dd0756bae6148f971db9a761d6a9"
+checksum = "aa1550d18fe8d97900148cc97d63a3212c3d53169c8469b9bf617de8953c05a8"
 dependencies = [
  "bitflags 1.3.2",
  "futures-core",
  "futures-sink",
  "glib",
- "glib-sys",
- "gobject-sys",
  "gstreamer",
  "gstreamer-app-sys",
  "gstreamer-base",
- "gstreamer-sys",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
 name = "gstreamer-app-sys"
-version = "0.8.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf869ce152c23bca5d761ab62146b47f750d0b28d4d499731857532897d48167"
+checksum = "d7cb5375aa8c23012ec5fadde1a37b972e87680776772669d2628772867056e2"
 dependencies = [
  "glib-sys",
  "gstreamer-base-sys",
  "gstreamer-sys",
  "libc",
- "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
 name = "gstreamer-audio"
-version = "0.15.7"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b0d857debf3abd07b85ec9ce59f0473009d8e3b00092ad9d3b9dafe44b10a01"
+checksum = "06b5a8658e575f6469053026ac663a348d5a562c9fce20ab2ca0c349e05d079e"
 dependencies = [
- "array-init",
  "bitflags 1.3.2",
+ "cfg-if 1.0.0",
  "glib",
- "glib-sys",
- "gobject-sys",
  "gstreamer",
  "gstreamer-audio-sys",
  "gstreamer-base",
- "gstreamer-base-sys",
- "gstreamer-sys",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
 name = "gstreamer-audio-sys"
-version = "0.8.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc91f53eec49fc31d6e0aea7502c4c4b502a4164e351b97fe81677f8a0ebce7"
+checksum = "9d4001b779e4707b32acd6ec0960e327b926369c1a34f7c41d477ac42b2670e8"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "gstreamer-base-sys",
  "gstreamer-sys",
  "libc",
- "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
 name = "gstreamer-base"
-version = "0.15.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42552f75cc6c260b0be180d5c955f4cd74bd170289c622404c25f1210b521c12"
+checksum = "0b8ff5dfbf7bcaf1466a385b836bad0d8da25759f121458727fdda1f771c69b3"
 dependencies = [
+ "atomic_refcell",
  "bitflags 1.3.2",
+ "cfg-if 1.0.0",
  "glib",
- "glib-sys",
- "gobject-sys",
  "gstreamer",
  "gstreamer-base-sys",
- "gstreamer-sys",
  "libc",
 ]
 
 [[package]]
 name = "gstreamer-base-sys"
-version = "0.8.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba384f52174b3c586593fca32642680a9e67961fea9f4cd8419f678965023bed"
+checksum = "26114ed96f6668380f5a1554128159e98e06c3a7a8460f216d7cd6dce28f928c"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "gstreamer-sys",
  "libc",
- "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
 name = "gstreamer-gl"
-version = "0.15.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af26f75082a835541e09a347df10bf433533302e454487e532011e3c96d1d52"
+checksum = "b82b83d18ad1c4d890694b4bedde170c748462a11f51a68428671bc1bf93e71e"
 dependencies = [
  "bitflags 1.3.2",
- "byteorder",
  "glib",
- "glib-sys",
- "gobject-sys",
  "gstreamer",
  "gstreamer-base",
  "gstreamer-gl-sys",
- "gstreamer-sys",
  "gstreamer-video",
- "gstreamer-video-sys",
- "lazy_static",
  "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "gstreamer-gl-egl"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec342886c7037cf18e07cf00aa5b60498ef5f9841aa36078a51f28d93970f93"
+dependencies = [
+ "glib",
+ "gstreamer",
+ "gstreamer-gl",
+ "gstreamer-gl-egl-sys",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-gl-egl-sys"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f6f24c488311f09198e41826634e5e693149f10c9da1f6aa1be9e4e81e414e"
+dependencies = [
+ "glib-sys",
+ "gstreamer-gl-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
 name = "gstreamer-gl-sys"
-version = "0.8.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d454ff57debf2573b0374b25aebb867d462298d3044cfb56caef64cde5baf68"
+checksum = "f08af9ae5ca5aa01c4875346bb7e61310b75a9afc3607b52a6b73470be93bbc7"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1086,143 +1120,191 @@ dependencies = [
  "gstreamer-sys",
  "gstreamer-video-sys",
  "libc",
- "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-gl-wayland"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e8229f920f1703cdd5415ed2a8caaa9dab7794be1a190bd7e3a3d91549f417"
+dependencies = [
+ "glib",
+ "gstreamer",
+ "gstreamer-gl",
+ "gstreamer-gl-wayland-sys",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-gl-wayland-sys"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7812f3fd82eb23c3f7f564b4d5c3b175dcc1e1947a4dcb93dde9129d9197232f"
+dependencies = [
+ "glib-sys",
+ "gstreamer-gl-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-gl-x11"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a82db426e6789bcb36e093100c97f8586f3a118bb7f268f36da9421044f646"
+dependencies = [
+ "glib",
+ "gstreamer",
+ "gstreamer-gl",
+ "gstreamer-gl-x11-sys",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-gl-x11-sys"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27467cb653e78d5d4b0b275f45b2bce6520f5b8b6a241867ae98f3c56f23f1"
+dependencies = [
+ "glib-sys",
+ "gstreamer-gl-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
 name = "gstreamer-player"
-version = "0.15.5"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b3497c644f0e4fa92195930801baabbae74ddb208a2a9f2127f36bf4d8f698"
+checksum = "ec5e04059f117b82ca64c40901610ca9ac1734383437c9fb69afba26c9ebf5a3"
 dependencies = [
  "bitflags 1.3.2",
  "glib",
- "glib-sys",
- "gobject-sys",
  "gstreamer",
  "gstreamer-player-sys",
- "gstreamer-sys",
  "gstreamer-video",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
 name = "gstreamer-player-sys"
-version = "0.8.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc38a730aed3442cad1c8df589b4abe856d14671058df7099a5a030fd61413c"
+checksum = "15321aaaf3bb247b4af3e09456a62dc17f030515d6328377a34081d9ed5803c0"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "gstreamer-sys",
  "gstreamer-video-sys",
  "libc",
- "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
 name = "gstreamer-sdp"
-version = "0.15.6"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547b3b0eb9e01e13ab5cc066c817e2ab758f83790145f80f62d3c8e43c2966af"
+checksum = "5bb57c03bfdbb0489bcab6e9b58a2c059e6089dcf660b424949dbe672af726bf"
 dependencies = [
  "glib",
- "glib-sys",
- "gobject-sys",
  "gstreamer",
  "gstreamer-sdp-sys",
- "gstreamer-sys",
 ]
 
 [[package]]
 name = "gstreamer-sdp-sys"
-version = "0.8.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e88ac4f9f20323ef3409dddcea3bbf58364ff8eea10b14da5303bfcb23347a"
+checksum = "be9ae71a2d53659f6da93a83ebe06de12c9e075604e012c45644499b24474e1a"
 dependencies = [
  "glib-sys",
- "gobject-sys",
  "gstreamer-sys",
  "libc",
- "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.8.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d18da01b97d0ab5896acd5151e4c155acefd0e6c03c3dd24dd133ba054053db"
+checksum = "e56fe047adef7d47dbafa8bc1340fddb53c325e16574763063702fc94b5786d2"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
 name = "gstreamer-video"
-version = "0.15.7"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad7e69a940246d41428c72072a376785716b3669da333cbee1156fd90574dc9"
+checksum = "dce97769effde2d779dc4f7037b37106457b74e53f2a711bddc90b30ffeb7e06"
 dependencies = [
  "bitflags 1.3.2",
+ "cfg-if 1.0.0",
  "futures-channel",
- "futures-util",
  "glib",
- "glib-sys",
- "gobject-sys",
  "gstreamer",
  "gstreamer-base",
- "gstreamer-base-sys",
- "gstreamer-sys",
  "gstreamer-video-sys",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
 name = "gstreamer-video-sys"
-version = "0.8.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615f4298f842f4b4581606e13cf52e1710e2130d989bb99161a5665aa3ccb7cc"
+checksum = "66ddb6112d438aac0004d2db6053a572f92b1c5e0e9d6ff6c71d9245f7f73e46"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "gstreamer-base-sys",
  "gstreamer-sys",
  "libc",
- "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
 name = "gstreamer-webrtc"
-version = "0.15.5"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f433d1294266fb1d65e1dc2d4de365f7f4caf23cb72db3a3bd6904eeec88cf1"
+checksum = "2550a5453b2afb9222a186a3cf2b56be3770f7c13fcac337a8cf79de323210f9"
 dependencies = [
  "glib",
- "glib-sys",
- "gobject-sys",
  "gstreamer",
  "gstreamer-sdp",
- "gstreamer-sys",
  "gstreamer-webrtc-sys",
  "libc",
 ]
 
 [[package]]
 name = "gstreamer-webrtc-sys"
-version = "0.8.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f392bd821b42efecfc21016c8ef20da188b45a45bbb5ddf81758704f93aae615"
+checksum = "b6feeb7a38db02ec4a0fb91e4e02da6c8448a7caa16b64128927b31e581e7bfa"
 dependencies = [
  "glib-sys",
- "gobject-sys",
  "gstreamer-sdp-sys",
  "gstreamer-sys",
  "libc",
- "pkg-config",
+ "system-deps",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1231,6 +1313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1277,6 +1368,16 @@ checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg 1.1.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1334,9 +1435,9 @@ checksum = "de0aaaba8809ab8d83a53fe2b313b996b79e8632b855eae9f70ad4323dca91b8"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
@@ -1371,9 +1472,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libloading"
@@ -1406,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
@@ -1452,7 +1553,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632647502a8bfa82458c07134791fffa7a719f00427d1afd79c3cb6d4960a982"
 dependencies = [
- "proc-macro2 1.0.64",
+ "proc-macro2 1.0.56",
  "syn 1.0.107",
  "synstructure",
 ]
@@ -1505,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.17"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
@@ -1563,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "muldiv"
-version = "0.2.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0419348c027fa7be448d2ae7ea0e4e04c2334c31dc4e74ab29f00a2a7ca69204"
+checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 
 [[package]]
 name = "native-tls"
@@ -1631,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
@@ -1704,8 +1805,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
  "syn 1.0.107",
 ]
 
@@ -1726,6 +1827,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "option-operations"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0"
+dependencies = [
+ "paste",
 ]
 
 [[package]]
@@ -1780,22 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.18"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
-dependencies = [
- "proc-macro-hack",
-]
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "peek-poke"
@@ -1811,8 +1908,8 @@ name = "peek-poke-derive"
 version = "0.2.1"
 source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#415b9ba32648667313f6f4ce7965752285bf0b26"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
  "syn 1.0.107",
  "synstructure",
  "unicode-xid 0.2.4",
@@ -1877,10 +1974,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
+name = "pretty-hex"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
+ "syn 1.0.107",
+ "version_check 0.9.4",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
+ "version_check 0.9.4",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1893,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -1917,11 +2048,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
- "proc-macro2 1.0.64",
+ "proc-macro2 1.0.56",
 ]
 
 [[package]]
@@ -2131,31 +2262,11 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
 ]
 
 [[package]]
@@ -2184,11 +2295,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2297,31 +2408,31 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.11"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a16be4fe5320ade08736447e3198294a5ea9a6d44dde6f35f0a5e06859c427a"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2332,6 +2443,15 @@ checksum = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
  "serde",
 ]
 
@@ -2410,7 +2530,7 @@ dependencies = [
  "ipc-channel",
  "lazy_static",
  "log 0.4.17",
- "mime 0.3.17",
+ "mime 0.3.16",
  "once_cell",
  "servo-media",
  "servo-media-audio",
@@ -2440,6 +2560,7 @@ dependencies = [
  "glib",
  "gstreamer",
  "gstreamer-gl",
+ "gstreamer-gl-egl",
  "gstreamer-video",
  "servo-media-gstreamer-render",
  "servo-media-player",
@@ -2452,6 +2573,9 @@ dependencies = [
  "glib",
  "gstreamer",
  "gstreamer-gl",
+ "gstreamer-gl-egl",
+ "gstreamer-gl-wayland",
+ "gstreamer-gl-x11",
  "gstreamer-video",
  "servo-media-gstreamer-render",
  "servo-media-player",
@@ -2504,8 +2628,8 @@ dependencies = [
 name = "servo_media_derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
  "syn 1.0.107",
 ]
 
@@ -2611,19 +2735,19 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
  "unicode-ident",
 ]
 
@@ -2633,21 +2757,40 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
  "syn 1.0.107",
  "unicode-xid 0.2.4",
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.8.0"
+name = "system-deps"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "e5fa6fb9ee296c0dc2df41a656ca7948546d061958115ddb0bcaae43ad0d17d2"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+
+[[package]]
+name = "tempfile"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -2676,8 +2819,8 @@ version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
  "syn 1.0.107",
 ]
 
@@ -2794,6 +2937,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tracy-rs"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,7 +2994,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 dependencies = [
- "version_check",
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -2883,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom",
 ]
@@ -2897,10 +3074,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+
+[[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"
@@ -2910,12 +3099,11 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -3140,13 +3328,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.1",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm 0.42.1",
- "windows_x86_64_msvc 0.42.1",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3160,102 +3348,102 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winit"
@@ -3280,6 +3468,15 @@ dependencies = [
  "wayland-client",
  "winapi 0.3.9",
  "x11-dl",
+]
+
+[[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3323,11 +3520,11 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
+checksum = "688597db5a750e9cad4511cb94729a078e274308099a0382b5b8203bbc767fee"
 dependencies = [
- "dirs",
+ "home",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -39,9 +39,9 @@ checksum = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 
 [[package]]
 name = "app_units"
-version = "0.7.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34655f9657fbb59fdd430438ba907566eb2d90b7fb0410d488d8ddabcd7b2cc9"
+checksum = "fc3ec9d4c47b25a5a9e5c848e053640331c7cedb1637434d75db68b79fee8a7f"
 dependencies = [
  "num-traits",
  "serde",
@@ -64,9 +64,9 @@ checksum = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
 
 [[package]]
 name = "atomic_refcell"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f2bfe491d41d45507b8431da8274f7feeca64a49e86d980eed2937ec2ff020"
+checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
 
 [[package]]
 name = "autocfg"
@@ -85,9 +85,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
@@ -125,10 +125,11 @@ checksum = "88ceb0d16c4fd0e42876e298d7d3ce3780dd9ebdcbe4199816a32c77e08597ff"
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7"
 dependencies = [
+ "byteorder",
  "serde",
 ]
 
@@ -140,9 +141,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block"
@@ -162,7 +163,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e3ff9db740167616e528c509b3618046fc05d337f8f3182d300f4aa977d2bb"
 dependencies = [
- "crossbeam-utils 0.8.16",
+ "crossbeam-utils 0.8.14",
  "jobserver",
  "num_cpus",
 ]
@@ -175,9 +176,9 @@ checksum = "28346c117b50270785fbc123bd6e4ecad20d0c6d5f43d081dc80a3abcc62be64"
 
 [[package]]
 name = "byteorder"
-version = "1.5.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -191,12 +192,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cesu8"
@@ -210,7 +208,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3"
 dependencies = [
- "smallvec 1.11.1",
+ "smallvec 1.10.0",
  "target-lexicon",
 ]
 
@@ -258,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.50"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
 dependencies = [
  "cc",
 ]
@@ -312,7 +310,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys 0.8.4",
+ "core-foundation-sys 0.8.3",
  "libc",
 ]
 
@@ -324,9 +322,9 @@ checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "core-graphics"
@@ -383,29 +381,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.16",
+ "crossbeam-utils 0.8.14",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.16",
+ "crossbeam-utils 0.8.14",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.16",
+ "crossbeam-utils 0.8.14",
  "memoffset",
  "scopeguard",
 ]
@@ -423,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -447,7 +445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd670e5ff58768ef624207fb95709ce63b8d05573fb9a05165f0eef471ea6a3a"
 dependencies = [
  "procedural-masquerade",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -463,10 +461,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "rustc_version 0.4.0",
- "syn 1.0.109",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -500,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "equivalent"
@@ -512,10 +530,11 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.7"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
+ "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -528,7 +547,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
- "windows-sys",
 ]
 
 [[package]]
@@ -539,9 +557,9 @@ checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 
 [[package]]
 name = "euclid"
-version = "0.22.9"
+version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787"
+checksum = "b52c2ef4a78da0ba68fbe1fd920627411096d2ac478f7f4c9f3a54ba6705bade"
 dependencies = [
  "num-traits",
  "serde",
@@ -589,17 +607,17 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 1.0.109",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.107",
  "synstructure",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fixedbitset"
@@ -630,11 +648,11 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "percent-encoding 2.3.0",
+ "percent-encoding 2.2.0",
 ]
 
 [[package]]
@@ -688,24 +706,24 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -714,32 +732,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -760,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -771,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "gio-sys"
@@ -795,7 +813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca98bbde17256e02d17336a6bdb5a50f7d0ccacee502e191d3e3d0ec2f96f84a"
 dependencies = [
  "khronos_api",
- "log 0.4.20",
+ "log 0.4.17",
  "xml-rs",
 ]
 
@@ -806,7 +824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
 dependencies = [
  "khronos_api",
- "log 0.4.20",
+ "log 0.4.17",
  "xml-rs",
 ]
 
@@ -830,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c316afb01ce8067c5eaab1fc4f2cd47dc21ce7b6296358605e2ffab23ccbd19"
+checksum = "58cf801b6f7829fa76db37449ab67c9c98a2b1bf21076d9113225621e61a0fa6"
 dependencies = [
  "bitflags 2.4.0",
  "futures-channel",
@@ -847,22 +865,22 @@ dependencies = [
  "libc",
  "memchr",
  "once_cell",
- "smallvec 1.11.1",
+ "smallvec 1.10.0",
  "thiserror",
 ]
 
 [[package]]
 name = "glib-macros"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8da903822b136d42360518653fcf154455defc437d3e7a81475bf9a95ff1e47"
+checksum = "72793962ceece3863c2965d7f10c8786323b17c7adea75a515809fa20ab799a5"
 dependencies = [
  "heck",
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -968,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b369a1eb2f7db49920d3d590bd988c5fb56dbf2347e1efb60307fe953546ee5d"
+checksum = "ed97f98d186e63e49079b26af1a1b73e70ab7a2f450eb46a136f2bffc2bf12d5"
 dependencies = [
  "cfg-if 1.0.0",
  "futures-channel",
@@ -985,16 +1003,17 @@ dependencies = [
  "num-rational",
  "option-operations",
  "paste",
+ "pin-project-lite",
  "pretty-hex",
- "smallvec 1.11.1",
+ "smallvec 1.10.0",
  "thiserror",
 ]
 
 [[package]]
 name = "gstreamer-app"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343376fe0a5b39e7e46fb0fed6a1ead4206ea34584c153130d0f20e51a480b80"
+checksum = "16bc8090a8806193237e7b6531ee429ff6e39686425f5c3eb06dfa75875390fb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1020,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-audio"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba605da8e756873456eebb35184d2c2f2b2ead7af18c5bfdc6c012d6cf8b6ee"
+checksum = "36d1678eacb7677c1ffdcf220ada416b5fb68e87c33b77319f14bba169fbe3fc"
 dependencies = [
  "cfg-if 1.0.0",
  "glib",
@@ -1048,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe38a6d5c1e516ce3fd6069e972a540d315448ed69fdadad739e6c6c6eb2a01"
+checksum = "cb150b6904a49052237fede7cc2e6479df6ced5043d95e6af8134bc141a3167f"
 dependencies = [
  "atomic_refcell",
  "cfg-if 1.0.0",
@@ -1075,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5caa903b631a00d7748efc3906d9108678162c5e15b87f83868d95ee85951613"
+checksum = "3ecfb91128263c160448a915a15e430cfdc69317b1b087316222e0693bb51b90"
 dependencies = [
  "glib",
  "gstreamer",
@@ -1089,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-egl"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8d9d4a058cad68285413b333b73bc90b4478734d0d6ab8a413d60aec25ae29"
+checksum = "a173ab223aa3c46d5f2be02b494c2086096fa3e932e2953d6392fcc07da5dc82"
 dependencies = [
  "glib",
  "gstreamer",
@@ -1102,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-egl-sys"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99ebc3ea45884fb78713ec14996dbca01920e8bcc8744c835fa82f251caa812"
+checksum = "ee3c88b6f01c8a5f9f7ba39f9805ac7026fd269fccb04d2a4b488bb928a8e954"
 dependencies = [
  "glib-sys",
  "gstreamer-gl-sys",
@@ -1114,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-gl-sys"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba5f511a1c0b4693b9f01b2d6b7dd7f1b5b476a16b8b25a89f4265e8108c34"
+checksum = "d580971b3c99a667c9739812d499e6c5cadbb92873f984cd0d1d0b4e7346f1cd"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1179,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-player"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68dc9772932f6133a9517742918b13ab5414db1f47e19daebc3027a1c3d20d2"
+checksum = "276900527b2f8323c6ed97ab3ed42854bb169a993fb8cef946fb43d1e9097a66"
 dependencies = [
  "glib",
  "gstreamer",
@@ -1229,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86bf9de67a6ab7af67ac11588f4939e984a936030437219f269fe969d79ad8c"
+checksum = "564cda782b3e6eed1b81cb4798a06794db56440fb05b422505be689f34ce3bc4"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1241,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b4d3141362b3d44a684e697d2bc55fea73d023315449cda83f0f4324531d64"
+checksum = "e85b2a4d1d3b7a98ae03806c3ed5c2db89d6b37a5f138780b48de015d68715e5"
 dependencies = [
  "cfg-if 1.0.0",
  "futures-channel",
@@ -1252,13 +1271,14 @@ dependencies = [
  "gstreamer-base",
  "gstreamer-video-sys",
  "libc",
+ "thiserror",
 ]
 
 [[package]]
 name = "gstreamer-video-sys"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cdc36baab839921b05d2468524da649f373dccc5f966c75e564029dc135b1c"
+checksum = "0302318d98e6b054501e485b6bb4ee20225823218f4a8660c182f115a33b16ee"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1270,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-webrtc"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab74a123e998f79bba3e823844be7e813d0eaad4169718bfe1f6613992fd905"
+checksum = "7200f2eb49d609afcb3e064b1ba75cbd041012a1855ea921b222e772634ff370"
 dependencies = [
  "glib",
  "gstreamer",
@@ -1296,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "heck"
@@ -1308,9 +1328,12 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "httparse"
@@ -1350,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1360,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1382,6 +1405,7 @@ name = "ipc-channel"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab3a34c91b7e84a72643bd75d1bac3afd241f78f9859fe0b5e5b2a6a75732c2"
+dependencies = [
  "bincode",
  "crossbeam-channel",
  "fnv",
@@ -1406,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jni"
@@ -1431,9 +1455,9 @@ checksum = "de0aaaba8809ab8d83a53fe2b313b996b79e8632b855eae9f70ad4323dca91b8"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
@@ -1468,9 +1492,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -1503,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.11"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -1522,14 +1546,17 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.20",
+ "log 0.4.17",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -1546,16 +1573,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632647502a8bfa82458c07134791fffa7a719f00427d1afd79c3cb6d4960a982"
 dependencies = [
- "proc-macro2 1.0.69",
- "syn 1.0.109",
+ "proc-macro2 1.0.64",
+ "syn 1.0.107",
  "synstructure",
 ]
 
 [[package]]
 name = "matches"
-version = "0.1.10"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "maybe-uninit"
@@ -1565,9 +1592,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap"
@@ -1581,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -1605,9 +1632,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -1624,7 +1651,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.20",
+ "log 0.4.17",
  "miow",
  "net2",
  "slab",
@@ -1669,7 +1696,7 @@ checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.20",
+ "log 0.4.17",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -1681,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.39"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
+checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1736,18 +1763,18 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg 1.1.0",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1764,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "2b8c786513eb403643f2a88c244c2aaa270ef2153f55094587d0c48a3cf22a83"
 dependencies = [
  "memchr",
 ]
@@ -1779,11 +1806,11 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -1794,13 +1821,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1811,10 +1838,11 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
+ "autocfg 1.1.0",
  "cc",
  "libc",
  "pkg-config",
@@ -1900,9 +1928,9 @@ name = "peek-poke-derive"
 version = "0.2.1"
 source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#415b9ba32648667313f6f4ce7965752285bf0b26"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 1.0.109",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.107",
  "synstructure",
  "unicode-xid 0.2.4",
 ]
@@ -1915,9 +1943,9 @@ checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
@@ -1931,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -1943,9 +1971,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plane-split"
@@ -1955,7 +1983,7 @@ checksum = "f3f7075ec146b897b6e0faca47adeb7ed3d4f6eaa8145bf19db17311081b3f63"
 dependencies = [
  "binary-space-partition",
  "euclid",
- "log 0.4.20",
+ "log 0.4.17",
  "num-traits",
 ]
 
@@ -1973,12 +2001,11 @@ checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -1988,9 +2015,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 1.0.109",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.107",
  "version_check 0.9.4",
 ]
 
@@ -2000,8 +2027,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "version_check 0.9.4",
 ]
 
@@ -2016,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2040,11 +2067,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.64",
 ]
 
 [[package]]
@@ -2217,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
  "either",
  "rayon-core",
@@ -2227,12 +2254,14 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
+ "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.16",
+ "crossbeam-utils 0.8.14",
+ "num_cpus",
 ]
 
 [[package]]
@@ -2252,18 +2281,38 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.23"
+name = "redox_syscall"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
@@ -2280,20 +2329,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.20",
+ "semver 1.0.17",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.24"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2318,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
 
 [[package]]
 name = "safemem"
@@ -2339,39 +2388,39 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.22"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.3",
- "core-foundation-sys 0.8.4",
+ "core-foundation-sys 0.8.3",
  "libc",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
- "core-foundation-sys 0.8.4",
+ "core-foundation-sys 0.8.3",
  "libc",
 ]
 
@@ -2386,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "semver-parser"
@@ -2398,38 +2447,38 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.12"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+checksum = "5a16be4fe5320ade08736447e3198294a5ea9a6d44dde6f35f0a5e06859c427a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
 dependencies = [
  "itoa",
  "ryu",
@@ -2438,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -2464,7 +2513,7 @@ dependencies = [
  "boxfnonce",
  "byte-slice-cast",
  "euclid",
- "log 0.4.20",
+ "log 0.4.17",
  "num-complex",
  "num-traits",
  "petgraph",
@@ -2474,7 +2523,7 @@ dependencies = [
  "servo-media-streams",
  "servo-media-traits",
  "servo_media_derive",
- "smallvec 1.11.1",
+ "smallvec 1.10.0",
  "speexdsp-resampler",
 ]
 
@@ -2518,7 +2567,8 @@ dependencies = [
  "gstreamer-video",
  "gstreamer-webrtc",
  "ipc-channel",
- "log 0.4.20",
+ "lazy_static",
+ "log 0.4.17",
  "mime 0.3.17",
  "once_cell",
  "servo-media",
@@ -2530,7 +2580,7 @@ dependencies = [
  "servo-media-streams",
  "servo-media-traits",
  "servo-media-webrtc",
- "url 2.4.1",
+ "url 2.3.1",
 ]
 
 [[package]]
@@ -2599,7 +2649,7 @@ version = "0.1.0"
 dependencies = [
  "boxfnonce",
  "lazy_static",
- "log 0.4.20",
+ "log 0.4.17",
  "servo-media-streams",
  "uuid",
 ]
@@ -2617,9 +2667,9 @@ dependencies = [
 name = "servo_media_derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 1.0.109",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2658,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -2676,9 +2726,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -2720,23 +2770,23 @@ checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "unicode-ident",
 ]
 
@@ -2746,17 +2796,17 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 1.0.109",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.107",
  "unicode-xid 0.2.4",
 ]
 
 [[package]]
 name = "system-deps"
-version = "6.1.2"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af52f9402f94aac4948a2518b43359be8d9ce6cd9efc1c4de3b2f7b7e897d6"
+checksum = "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331"
 dependencies = [
  "cfg-expr",
  "heck",
@@ -2767,21 +2817,21 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2795,22 +2845,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2835,9 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio-codec"
@@ -2868,7 +2918,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes",
  "futures",
- "log 0.4.20",
+ "log 0.4.17",
 ]
 
 [[package]]
@@ -2879,6 +2929,7 @@ checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "futures",
+ "lazy_static",
  "log 0.4.17",
  "mio 0.6.23",
  "num_cpus",
@@ -2926,30 +2977,30 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.2",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2958,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap",
  "serde",
@@ -2998,15 +3049,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "0046be40136ef78dc325e0edefccf84ccddacd0afcc1ca54103fa3c61bbdab1d"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -3019,9 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -3048,20 +3099,20 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna 0.4.0",
- "percent-encoding 2.3.0",
+ "idna 0.3.0",
+ "percent-encoding 2.2.0",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.5.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom",
 ]
@@ -3098,11 +3149,12 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -3200,13 +3252,13 @@ dependencies = [
  "glslopt",
  "lazy_static",
  "libc",
- "log 0.4.20",
+ "log 0.4.17",
  "malloc_size_of_derive",
  "num-traits",
  "plane-split",
  "rayon",
  "sig",
- "smallvec 1.11.1",
+ "smallvec 1.10.0",
  "svg_fmt",
  "time",
  "tracy-rs",
@@ -3299,9 +3351,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -3323,6 +3375,21 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -3336,14 +3403,20 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3353,9 +3426,21 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3365,9 +3450,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3377,9 +3474,21 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3401,10 +3510,10 @@ dependencies = [
  "core-graphics 0.17.3",
  "lazy_static",
  "libc",
- "log 0.4.20",
+ "log 0.4.17",
  "objc",
  "parking_lot",
- "percent-encoding 2.3.0",
+ "percent-encoding 2.2.0",
  "raw-window-handle 0.3.4",
  "smithay-client-toolkit",
  "wayland-client",
@@ -3414,9 +3523,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.16"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]
@@ -3462,12 +3571,15 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.19"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,7 +2529,6 @@ dependencies = [
  "gstreamer-video",
  "gstreamer-webrtc",
  "ipc-channel",
- "lazy_static",
  "log 0.4.20",
  "mime 0.3.17",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -39,15 +39,15 @@ checksum = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "app_units"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3ec9d4c47b25a5a9e5c848e053640331c7cedb1637434d75db68b79fee8a7f"
+checksum = "34655f9657fbb59fdd430438ba907566eb2d90b7fb0410d488d8ddabcd7b2cc9"
 dependencies = [
  "num-traits",
  "serde",
@@ -70,9 +70,9 @@ checksum = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
 
 [[package]]
 name = "atomic_refcell"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d6dc922a2792b006573f60b2648076355daeae5ce9cb59507e5908c9625d31"
+checksum = "76f2bfe491d41d45507b8431da8274f7feeca64a49e86d980eed2937ec2ff020"
 
 [[package]]
 name = "autocfg"
@@ -91,9 +91,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -131,11 +131,10 @@ checksum = "88ceb0d16c4fd0e42876e298d7d3ce3780dd9ebdcbe4199816a32c77e08597ff"
 
 [[package]]
 name = "bincode"
-version = "1.0.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "byteorder",
  "serde",
 ]
 
@@ -169,7 +168,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e3ff9db740167616e528c509b3618046fc05d337f8f3182d300f4aa977d2bb"
 dependencies = [
- "crossbeam-utils 0.8.14",
+ "crossbeam-utils 0.8.16",
  "jobserver",
  "num_cpus",
 ]
@@ -182,9 +181,9 @@ checksum = "28346c117b50270785fbc123bd6e4ecad20d0c6d5f43d081dc80a3abcc62be64"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -198,9 +197,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cesu8"
@@ -210,11 +212,11 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8790cf1286da485c72cf5fc7aeba308438800036ec67d89425924c4807268c9"
+checksum = "03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3"
 dependencies = [
- "smallvec 1.10.0",
+ "smallvec 1.11.1",
  "target-lexicon",
 ]
 
@@ -262,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
@@ -316,7 +318,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys 0.8.3",
+ "core-foundation-sys 0.8.4",
  "libc",
 ]
 
@@ -328,9 +330,9 @@ checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core-graphics"
@@ -382,34 +384,34 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.14",
+ "crossbeam-utils 0.8.16",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.14",
+ "crossbeam-utils 0.8.16",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.14",
+ "crossbeam-utils 0.8.16",
  "memoffset",
  "scopeguard",
 ]
@@ -427,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -451,7 +453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd670e5ff58768ef624207fb95709ce63b8d05573fb9a05165f0eef471ea6a3a"
 dependencies = [
  "procedural-masquerade",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -467,10 +469,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.56",
- "quote 1.0.27",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "rustc_version 0.4.0",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -504,9 +506,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -526,10 +534,10 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+ "windows-sys",
 ]
 
 [[package]]
->>>>>>> 1d46db2 (Fix dependencies definition)
 name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,9 +545,9 @@ checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 
 [[package]]
 name = "euclid"
-version = "0.22.7"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52c2ef4a78da0ba68fbe1fd920627411096d2ac478f7f4c9f3a54ba6705bade"
+checksum = "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787"
 dependencies = [
  "num-traits",
  "serde",
@@ -587,9 +595,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 1.0.107",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 1.0.109",
  "synstructure",
 ]
 
@@ -628,11 +636,11 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
- "percent-encoding 2.2.0",
+ "percent-encoding 2.3.0",
 ]
 
 [[package]]
@@ -686,24 +694,24 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -712,32 +720,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 1.0.107",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -758,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -769,15 +777,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "gio-sys"
-version = "0.17.4"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1d43b0d7968b48455244ecafe41192871257f5740aa6b095eb19db78e362a5"
+checksum = "0ccf87c30a12c469b6d958950f6a9c09f2be20b7773f7e70d20b867fdf2628c3"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -793,7 +801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca98bbde17256e02d17336a6bdb5a50f7d0ccacee502e191d3e3d0ec2f96f84a"
 dependencies = [
  "khronos_api",
- "log 0.4.17",
+ "log 0.4.20",
  "xml-rs",
 ]
 
@@ -804,7 +812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
 dependencies = [
  "khronos_api",
- "log 0.4.17",
+ "log 0.4.20",
  "xml-rs",
 ]
 
@@ -828,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.17.9"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1de7cbde31ea4f0a919453a2dcece5d54d5b70e08f8ad254dc4840f5f09b6"
+checksum = "d3fad45ba8d4d2cea612b432717e834f48031cd8853c8aaf43b2c79fec8d144b"
 dependencies = [
  "bitflags 1.3.2",
  "futures-channel",
@@ -845,30 +853,30 @@ dependencies = [
  "libc",
  "memchr",
  "once_cell",
- "smallvec 1.10.0",
+ "smallvec 1.11.1",
  "thiserror",
 ]
 
 [[package]]
 name = "glib-macros"
-version = "0.17.9"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7206c5c03851ef126ea1444990e81fdd6765fb799d5bc694e4897ca01bb97f"
+checksum = "eca5c79337338391f1ab8058d6698125034ce8ef31b72a442437fa6c8580de26"
 dependencies = [
  "anyhow",
  "heck",
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 1.0.107",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.17.4"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f00ad0a1bf548e61adfff15d83430941d9e1bb620e334f779edd1c745680a5"
+checksum = "d80aa6ea7bba0baac79222204aa786a6293078c210abe69ef1336911d4bdc4f0"
 dependencies = [
  "libc",
  "system-deps",
@@ -956,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.17.4"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e75b0000a64632b2d8ca3cf856af9308e3a970844f6e9659bd197f026793d0"
+checksum = "cd34c3317740a6358ec04572c1bcfd3ac0b5b6529275fae255b237b314bb8062"
 dependencies = [
  "glib-sys",
  "libc",
@@ -967,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.20.5"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4530401c89be6dc10d77ae1587b811cf455c97dce7abf594cb9164527c7da7fc"
+checksum = "c0a4150420d4aa1caf6fa15f0dba7a5007d4116380633bd1253acce206098fc9"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
@@ -986,15 +994,15 @@ dependencies = [
  "option-operations",
  "paste",
  "pretty-hex",
- "smallvec 1.10.0",
+ "smallvec 1.11.1",
  "thiserror",
 ]
 
 [[package]]
 name = "gstreamer-app"
-version = "0.20.0"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1550d18fe8d97900148cc97d63a3212c3d53169c8469b9bf617de8953c05a8"
+checksum = "fe9a6d39222f708ba3a55f259261452daf4fc0d36693fe14126a630beb6461a8"
 dependencies = [
  "bitflags 1.3.2",
  "futures-core",
@@ -1022,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-audio"
-version = "0.20.4"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06b5a8658e575f6469053026ac663a348d5a562c9fce20ab2ca0c349e05d079e"
+checksum = "8448db43cee0270c6ca94e6771c92a4c3b14c51ac1e6605a5f2deef66f5516f1"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
@@ -1052,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base"
-version = "0.20.5"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8ff5dfbf7bcaf1466a385b836bad0d8da25759f121458727fdda1f771c69b3"
+checksum = "c0896c4acff303dd21d6a96a7ea4cc9339f7096230fe1433720c9f0bed203985"
 dependencies = [
  "atomic_refcell",
  "bitflags 1.3.2",
@@ -1063,6 +1071,7 @@ dependencies = [
  "gstreamer",
  "gstreamer-base-sys",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -1250,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video"
-version = "0.20.4"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce97769effde2d779dc4f7037b37106457b74e53f2a711bddc90b30ffeb7e06"
+checksum = "b69a9554795d3791b8467a30b35ed40ef279aa41c857e6f414ffd6a182a20225"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
@@ -1307,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "heck"
@@ -1319,21 +1328,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "home"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
-dependencies = [
- "windows-sys 0.48.0",
-]
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "httparse"
@@ -1373,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1383,11 +1380,11 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
- "autocfg 1.1.0",
+ "equivalent",
  "hashbrown",
 ]
 
@@ -1420,9 +1417,9 @@ checksum = "7ab3a34c91b7e84a72643bd75d1bac3afd241f78f9859fe0b5e5b2a6a75732c2"
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jni"
@@ -1536,17 +1533,14 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.17",
+ "log 0.4.20",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "malloc_buf"
@@ -1563,16 +1557,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632647502a8bfa82458c07134791fffa7a719f00427d1afd79c3cb6d4960a982"
 dependencies = [
- "proc-macro2 1.0.56",
- "syn 1.0.107",
+ "proc-macro2 1.0.68",
+ "syn 1.0.109",
  "synstructure",
 ]
 
 [[package]]
 name = "matches"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "maybe-uninit"
@@ -1582,9 +1576,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap"
@@ -1598,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -1616,15 +1610,15 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -1641,7 +1635,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.17",
+ "log 0.4.20",
  "miow",
  "net2",
  "slab",
@@ -1686,7 +1680,7 @@ checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.17",
+ "log 0.4.20",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -1698,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.38"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1753,18 +1747,18 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg 1.1.0",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1781,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.2"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8c786513eb403643f2a88c244c2aaa270ef2153f55094587d0c48a3cf22a83"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -1796,11 +1790,11 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -1811,13 +1805,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 1.0.107",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1828,11 +1822,10 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
- "autocfg 1.1.0",
  "cc",
  "libc",
  "pkg-config",
@@ -1900,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "peek-poke"
@@ -1918,9 +1911,9 @@ name = "peek-poke-derive"
 version = "0.2.1"
 source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#415b9ba32648667313f6f4ce7965752285bf0b26"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 1.0.107",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 1.0.109",
  "synstructure",
  "unicode-xid 0.2.4",
 ]
@@ -1933,9 +1926,9 @@ checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
@@ -1949,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1961,9 +1954,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plane-split"
@@ -1973,7 +1966,7 @@ checksum = "f3f7075ec146b897b6e0faca47adeb7ed3d4f6eaa8145bf19db17311081b3f63"
 dependencies = [
  "binary-space-partition",
  "euclid",
- "log 0.4.17",
+ "log 0.4.20",
  "num-traits",
 ]
 
@@ -1996,7 +1989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -2006,9 +1999,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 1.0.107",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 1.0.109",
  "version_check 0.9.4",
 ]
 
@@ -2018,8 +2011,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "version_check 0.9.4",
 ]
 
@@ -2034,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
 dependencies = [
  "unicode-ident",
 ]
@@ -2058,11 +2051,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.68",
 ]
 
 [[package]]
@@ -2235,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -2245,14 +2238,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.14",
- "num_cpus",
+ "crossbeam-utils 0.8.16",
 ]
 
 [[package]]
@@ -2281,9 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"
@@ -2300,7 +2291,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.17",
+ "semver 1.0.19",
 ]
 
 [[package]]
@@ -2313,7 +2304,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2338,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "0.2.8"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "safemem"
@@ -2359,39 +2350,39 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.8.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.3",
- "core-foundation-sys 0.8.3",
+ "core-foundation-sys 0.8.4",
  "libc",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
- "core-foundation-sys 0.8.3",
+ "core-foundation-sys 0.8.4",
  "libc",
 ]
 
@@ -2406,9 +2397,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
 
 [[package]]
 name = "semver-parser"
@@ -2418,38 +2409,38 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.9"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 2.0.15",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.32"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -2458,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
 ]
@@ -2484,7 +2475,7 @@ dependencies = [
  "boxfnonce",
  "byte-slice-cast",
  "euclid",
- "log 0.4.17",
+ "log 0.4.20",
  "num-complex",
  "num-traits",
  "petgraph",
@@ -2494,7 +2485,7 @@ dependencies = [
  "servo-media-streams",
  "servo-media-traits",
  "servo_media_derive",
- "smallvec 1.10.0",
+ "smallvec 1.11.1",
  "speexdsp-resampler",
 ]
 
@@ -2539,8 +2530,8 @@ dependencies = [
  "gstreamer-webrtc",
  "ipc-channel",
  "lazy_static",
- "log 0.4.17",
- "mime 0.3.16",
+ "log 0.4.20",
+ "mime 0.3.17",
  "once_cell",
  "servo-media",
  "servo-media-audio",
@@ -2551,7 +2542,7 @@ dependencies = [
  "servo-media-streams",
  "servo-media-traits",
  "servo-media-webrtc",
- "url 2.3.1",
+ "url 2.4.1",
 ]
 
 [[package]]
@@ -2620,7 +2611,7 @@ version = "0.1.0"
 dependencies = [
  "boxfnonce",
  "lazy_static",
- "log 0.4.17",
+ "log 0.4.20",
  "servo-media-streams",
  "uuid",
 ]
@@ -2638,9 +2629,9 @@ dependencies = [
 name = "servo_media_derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 1.0.107",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2679,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -2697,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -2741,23 +2732,23 @@ checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
@@ -2767,17 +2758,17 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 1.0.107",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 1.0.109",
  "unicode-xid 0.2.4",
 ]
 
 [[package]]
 name = "system-deps"
-version = "6.1.0"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fa6fb9ee296c0dc2df41a656ca7948546d061958115ddb0bcaae43ad0d17d2"
+checksum = "94af52f9402f94aac4948a2518b43359be8d9ce6cd9efc1c4de3b2f7b7e897d6"
 dependencies = [
  "cfg-expr",
  "heck",
@@ -2788,9 +2779,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.7"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "tempfile"
@@ -2802,7 +2793,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.4.1",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2816,22 +2807,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 1.0.107",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2856,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio-codec"
@@ -2889,7 +2880,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes",
  "futures",
- "log 0.4.17",
+ "log 0.4.20",
 ]
 
 [[package]]
@@ -2900,7 +2891,6 @@ checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "futures",
- "lazy_static",
  "log 0.4.17",
  "mio 0.6.23",
  "num_cpus",
@@ -2948,30 +2938,41 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",
@@ -3009,15 +3010,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046be40136ef78dc325e0edefccf84ccddacd0afcc1ca54103fa3c61bbdab1d"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -3030,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
@@ -3059,13 +3060,13 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
- "idna 0.3.0",
- "percent-encoding 2.2.0",
+ "idna 0.4.0",
+ "percent-encoding 2.3.0",
 ]
 
 [[package]]
@@ -3109,9 +3110,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -3211,13 +3212,13 @@ dependencies = [
  "glslopt",
  "lazy_static",
  "libc",
- "log 0.4.17",
+ "log 0.4.20",
  "malloc_size_of_derive",
  "num-traits",
  "plane-split",
  "rayon",
  "sig",
- "smallvec 1.10.0",
+ "smallvec 1.11.1",
  "svg_fmt",
  "time",
  "tracy-rs",
@@ -3310,9 +3311,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -3334,21 +3335,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -3358,102 +3344,60 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winit"
@@ -3469,10 +3413,10 @@ dependencies = [
  "core-graphics 0.17.3",
  "lazy_static",
  "libc",
- "log 0.4.17",
+ "log 0.4.20",
  "objc",
  "parking_lot",
- "percent-encoding 2.2.0",
+ "percent-encoding 2.3.0",
  "raw-window-handle 0.3.4",
  "smithay-client-toolkit",
  "wayland-client",
@@ -3482,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
 dependencies = [
  "memchr",
 ]
@@ -3530,15 +3474,12 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688597db5a750e9cad4511cb94729a078e274308099a0382b5b8203bbc767fee"
-dependencies = [
- "home",
-]
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.4"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+>>>>>>> 1d46db2 (Fix dependencies definition)
 name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,7 +1405,6 @@ name = "ipc-channel"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab3a34c91b7e84a72643bd75d1bac3afd241f78f9859fe0b5e5b2a6a75732c2"
-dependencies = [
  "bincode",
  "crossbeam-channel",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "audio",
   "backends/auto",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,10 +20,10 @@ cache:
 
 install:
   - appveyor-retry choco install pkgconfiglite
-  - appveyor-retry appveyor DownloadFile https://gstreamer.freedesktop.org/data/pkg/windows/1.16.0/gstreamer-1.0-devel-msvc-x86_64-1.16.0.msi
-  - appveyor-retry appveyor DownloadFile https://gstreamer.freedesktop.org/data/pkg/windows/1.16.0/gstreamer-1.0-msvc-x86_64-1.16.0.msi
-  - msiexec /i gstreamer-1.0-devel-msvc-x86_64-1.16.0.msi /quiet /qn /norestart /log install-devel.log ADDLOCAL=ALL
-  - msiexec /i gstreamer-1.0-msvc-x86_64-1.16.0.msi /quiet /qn /norestart /log install.log ADDLOCAL=ALL
+  - appveyor-retry appveyor DownloadFile https://gstreamer.freedesktop.org/data/pkg/windows/1.22.2/msvc/gstreamer-1.0-devel-msvc-x86_64-1.22.2.msi
+  - appveyor-retry appveyor DownloadFile https://gstreamer.freedesktop.org/data/pkg/windows/1.22.2/msvc/gstreamer-1.0-msvc-x86_64-1.22.2.msi
+  - msiexec /i gstreamer-1.0-devel-msvc-x86_64-1.22.2.msi /quiet /qn /norestart /log install-devel.log ADDLOCAL=ALL
+  - msiexec /i gstreamer-1.0-msvc-x86_64-1.22.2.msi /quiet /qn /norestart /log install.log ADDLOCAL=ALL
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly

--- a/backends/auto/Cargo.toml
+++ b/backends/auto/Cargo.toml
@@ -2,13 +2,14 @@
 name = "servo-media-auto"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
+edition = "2021"
 
 [lib]
 name = "servo_media_auto"
 path = "lib.rs"
 
-[target.'cfg(any(all(target_os = "android", any(target_arch = "arm", target_arch = "aarch64")), target_arch = "x86_64"))'.dependencies.servo-media-gstreamer]
+[target.'cfg(any(all(target_os = "android", any(target_arch = "arm", target_arch = "aarch64")), target_arch = "x86_64",target_arch = "aarch64"))'.dependencies.servo-media-gstreamer]
 path = "../gstreamer"
 
-[target.'cfg(not(any(all(target_os = "android", any(target_arch = "arm", target_arch = "aarch64")), target_arch = "x86_64")))'.dependencies.servo-media-dummy]
+[target.'cfg(not(any(all(target_os = "android", any(target_arch = "arm", target_arch = "aarch64")), target_arch = "x86_64", target_arch = "aarch64")))'.dependencies.servo-media-dummy]
 path = "../dummy"

--- a/backends/auto/lib.rs
+++ b/backends/auto/lib.rs
@@ -3,11 +3,11 @@
         target_os = "android",
         any(target_arch = "arm", target_arch = "aarch64")
     ),
-    target_arch = "x86_64"
+    target_arch = "x86_64",
+    target_arch = "aarch64",
 ))]
 mod platform {
-    extern crate servo_media_gstreamer;
-    pub use self::servo_media_gstreamer::GStreamerBackend as Backend;
+    pub use servo_media_gstreamer::GStreamerBackend as Backend;
 }
 
 #[cfg(not(any(
@@ -15,11 +15,11 @@ mod platform {
         target_os = "android",
         any(target_arch = "arm", target_arch = "aarch64")
     ),
-    target_arch = "x86_64"
+    target_arch = "x86_64",
+    target_arch = "aarch64",
 )))]
 mod platform {
-    extern crate servo_media_dummy;
-    pub use self::servo_media_dummy::DummyBackend as Backend;
+    pub use servo_media_dummy::DummyBackend as Backend;
 }
 
 pub type Backend = platform::Backend;

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "servo-media-gstreamer"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
+edition = "2021"
 
 [lib]
 name = "servo_media_gstreamer"
@@ -10,17 +11,17 @@ path = "lib.rs"
 [dependencies]
 boxfnonce = "0.1.0"
 byte-slice-cast = "0.2"
-glib = "0.9"
-glib-sys = "0.9"
-gstreamer = "0.15"
-gstreamer-app = "0.15"
-gstreamer-audio = "0.15"
-gstreamer-base = "0.15"
-gstreamer-sys = "0.8"
-gstreamer-player = "0.15"
-gstreamer-sdp = "0.15"
-gstreamer-video = "0.15"
-gstreamer-webrtc = { version = "0.15", features = ["v1_16"] }
+glib = "0.17"
+glib-sys = "0.17"
+gstreamer = "0.20"
+gstreamer-app = "0.20"
+gstreamer-audio = "0.20"
+gstreamer-base = "0.20"
+gstreamer-sys = "0.20"
+gstreamer-player = "0.20"
+gstreamer-sdp = "0.20"
+gstreamer-video = "0.20"
+gstreamer-webrtc = { version = "0.20", features = ["v1_18"] }
 ipc-channel = { workspace = true }
 lazy_static = "1.2.0"
 log = "0.4"

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -11,17 +11,17 @@ path = "lib.rs"
 [dependencies]
 boxfnonce = "0.1.0"
 byte-slice-cast = "0.2"
-glib = "0.17"
-glib-sys = "0.17"
-gst = { package = "gstreamer", version = "0.20" }
-gst-app = { package = "gstreamer-app", version = "0.20" }
-gst-audio = { package = "gstreamer-audio", version = "0.20" }
-gst-video = { package = "gstreamer-video", version = "0.20" }
-gst-base = { package = "gstreamer-base", version = "0.20" }
-gst-player = { package = "gstreamer-player", version = "0.20" }
-gst-webrtc = { package = "gstreamer-webrtc", version = "0.20", features = ["v1_18"] }
-gst-sdp = { package = "gstreamer-sdp", version = "0.20" }
-gstreamer-sys = "0.20"
+glib = "0.18"
+glib-sys = "0.18"
+gst = { package = "gstreamer", version = "0.21" }
+gst-app = { package = "gstreamer-app", version = "0.21" }
+gst-audio = { package = "gstreamer-audio", version = "0.21" }
+gst-video = { package = "gstreamer-video", version = "0.21" }
+gst-base = { package = "gstreamer-base", version = "0.21" }
+gst-player = { package = "gstreamer-player", version = "0.21" }
+gst-webrtc = { package = "gstreamer-webrtc", version = "0.21", features = ["v1_18"] }
+gst-sdp = { package = "gstreamer-sdp", version = "0.21" }
+gstreamer-sys = "0.21"
 ipc-channel = { workspace = true }
 lazy_static = "1.2.0"
 log = "0.4"

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -13,14 +13,15 @@ boxfnonce = "0.1.0"
 byte-slice-cast = "0.2"
 glib = "0.17"
 glib-sys = "0.17"
-gstreamer = "0.20"
-gstreamer-app = "0.20"
-gstreamer-audio = "0.20"
-gstreamer-base = "0.20"
+gst = { package = "gstreamer", version = "0.20" }
+gst-app = { package = "gstreamer-app", version = "0.20" }
+gst-audio = { package = "gstreamer-audio", version = "0.20" }
+gst-video = { package = "gstreamer-video", version = "0.20" }
+gst-base = { package = "gstreamer-base", version = "0.20" }
+gst-player = { package = "gstreamer-player", version = "0.20" }
+gst-webrtc = { package = "gstreamer-webrtc", version = "0.20", features = ["v1_18"] }
+gst-sdp = { package = "gstreamer-sdp", version = "0.20" }
 gstreamer-sys = "0.20"
-gstreamer-player = "0.20"
-gstreamer-sdp = "0.20"
-gstreamer-video = "0.20"
 gstreamer-webrtc = { version = "0.20", features = ["v1_18"] }
 ipc-channel = { workspace = true }
 lazy_static = "1.2.0"

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -22,7 +22,6 @@ gst-player = { package = "gstreamer-player", version = "0.20" }
 gst-webrtc = { package = "gstreamer-webrtc", version = "0.20", features = ["v1_18"] }
 gst-sdp = { package = "gstreamer-sdp", version = "0.20" }
 gstreamer-sys = "0.20"
-gstreamer-webrtc = { version = "0.20", features = ["v1_18"] }
 ipc-channel = { workspace = true }
 lazy_static = "1.2.0"
 log = "0.4"

--- a/backends/gstreamer/audio_decoder.rs
+++ b/backends/gstreamer/audio_decoder.rs
@@ -32,7 +32,7 @@ impl AudioDecoder for GStreamerAudioDecoder {
         callbacks: AudioDecoderCallbacks,
         options: Option<AudioDecoderOptions>,
     ) {
-        let pipeline = gst::Pipeline::new(None);
+        let pipeline = gst::Pipeline::new();
         let callbacks = Arc::new(callbacks);
 
         let appsrc = match gst::ElementFactory::make("appsrc").build() {

--- a/backends/gstreamer/audio_sink.rs
+++ b/backends/gstreamer/audio_sink.rs
@@ -36,7 +36,7 @@ impl GStreamerAudioSink {
         let appsrc = appsrc.downcast::<AppSrc>().unwrap();
 
         Ok(Self {
-            pipeline: gst::Pipeline::new(None),
+            pipeline: gst::Pipeline::new(),
             appsrc: Arc::new(appsrc),
             sample_rate: Cell::new(DEFAULT_SAMPLE_RATE),
             audio_info: RefCell::new(None),

--- a/backends/gstreamer/device_monitor.rs
+++ b/backends/gstreamer/device_monitor.rs
@@ -1,8 +1,5 @@
-use gst::Caps;
-use gst::DeviceExt;
+use gst::prelude::*;
 use gst::DeviceMonitor as GstDeviceMonitor;
-use gst::DeviceMonitorExt;
-use gst::DeviceMonitorExtManual;
 use std::cell::RefCell;
 
 use servo_media_streams::device_monitor::{MediaDeviceInfo, MediaDeviceKind, MediaDeviceMonitor};
@@ -23,19 +20,19 @@ impl GStreamerDeviceMonitor {
         const AUDIO_SINK: &str = "Audio/Sink";
         const VIDEO_SOURCE: &str = "Video/Source";
         let device_monitor = GstDeviceMonitor::new();
-        let audio_caps = Caps::new_simple("audio/x-raw", &[]);
+        let audio_caps = gst_audio::AudioCapsBuilder::new().build();
         device_monitor.add_filter(Some(AUDIO_SOURCE), Some(&audio_caps));
         device_monitor.add_filter(Some(AUDIO_SINK), Some(&audio_caps));
-        let video_caps = Caps::new_simple("video/x-raw", &[]);
+        let video_caps = gst_video::VideoCapsBuilder::new().build();
         device_monitor.add_filter(Some(VIDEO_SOURCE), Some(&video_caps));
         let devices = device_monitor
-            .get_devices()
+            .devices()
             .iter()
             .filter_map(|device| {
-                let display_name = device.get_display_name().as_str().to_owned();
+                let display_name = device.display_name().as_str().to_owned();
                 Some(MediaDeviceInfo {
                     device_id: display_name.clone(),
-                    kind: match device.get_device_class().as_str() {
+                    kind: match device.device_class().as_str() {
                         AUDIO_SOURCE => MediaDeviceKind::AudioInput,
                         AUDIO_SINK => MediaDeviceKind::AudioOutput,
                         VIDEO_SOURCE => MediaDeviceKind::VideoInput,

--- a/backends/gstreamer/lib.rs
+++ b/backends/gstreamer/lib.rs
@@ -1,37 +1,3 @@
-extern crate boxfnonce;
-extern crate byte_slice_cast;
-extern crate mime;
-
-extern crate glib_sys as glib_ffi;
-extern crate gstreamer_sys as gst_ffi;
-
-#[macro_use]
-extern crate glib;
-#[macro_use]
-extern crate gstreamer as gst;
-extern crate gstreamer_app as gst_app;
-extern crate gstreamer_audio as gst_audio;
-extern crate gstreamer_base as gst_base;
-extern crate gstreamer_player as gst_player;
-extern crate gstreamer_sdp as gst_sdp;
-extern crate gstreamer_video as gst_video;
-extern crate gstreamer_webrtc as gst_webrtc;
-extern crate ipc_channel;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-extern crate once_cell;
-
-extern crate servo_media;
-extern crate servo_media_audio;
-extern crate servo_media_gstreamer_render;
-extern crate servo_media_player;
-extern crate servo_media_streams;
-extern crate servo_media_traits;
-extern crate servo_media_webrtc;
-extern crate url;
-
 pub mod audio_decoder;
 pub mod audio_sink;
 pub mod audio_stream_reader;
@@ -47,8 +13,10 @@ mod source;
 pub mod webrtc;
 
 use device_monitor::GStreamerDeviceMonitor;
-use gst::ClockExt;
+use gst::prelude::*;
 use ipc_channel::ipc::IpcSender;
+use lazy_static::lazy_static;
+use log::warn;
 use media_stream::GStreamerMediaStream;
 use mime::Mime;
 use once_cell::sync::OnceCell;
@@ -77,7 +45,7 @@ use std::thread;
 use std::vec::Vec;
 
 lazy_static! {
-    static ref BACKEND_BASE_TIME: gst::ClockTime = gst::SystemClock::obtain().get_time();
+    static ref BACKEND_BASE_TIME: gst::ClockTime = gst::SystemClock::obtain().time().unwrap();
 }
 
 static BACKEND_THREAD: OnceCell<bool> = OnceCell::new();
@@ -358,39 +326,5 @@ impl WebRtcBackend for GStreamerBackend {
 impl BackendInit for GStreamerBackend {
     fn init() -> Box<dyn Backend> {
         Self::init_with_plugins(PathBuf::new(), &[]).unwrap()
-    }
-}
-
-pub fn set_element_flags<T: glib::IsA<gst::Object> + glib::IsA<gst::Element>>(
-    element: &T,
-    flags: gst::ElementFlags,
-) {
-    unsafe {
-        use glib::translate::ToGlib;
-
-        let ptr: *mut gst_ffi::GstObject = element.as_ptr() as *mut _;
-        let _guard = MutexGuard::lock(&(*ptr).lock);
-        (*ptr).flags |= flags.to_glib();
-    }
-}
-
-struct MutexGuard<'a>(&'a glib_ffi::GMutex);
-
-impl<'a> MutexGuard<'a> {
-    pub fn lock(mutex: &'a glib_ffi::GMutex) -> Self {
-        use glib::translate::mut_override;
-        unsafe {
-            glib_ffi::g_mutex_lock(mut_override(mutex));
-        }
-        MutexGuard(mutex)
-    }
-}
-
-impl<'a> Drop for MutexGuard<'a> {
-    fn drop(&mut self) {
-        use glib::translate::mut_override;
-        unsafe {
-            glib_ffi::g_mutex_unlock(mut_override(self.0));
-        }
     }
 }

--- a/backends/gstreamer/lib.rs
+++ b/backends/gstreamer/lib.rs
@@ -13,9 +13,9 @@ mod source;
 pub mod webrtc;
 
 use device_monitor::GStreamerDeviceMonitor;
+use glib::once_cell::sync::Lazy;
 use gst::prelude::*;
 use ipc_channel::ipc::IpcSender;
-use glib::once_cell::sync::Lazy;
 use log::warn;
 use media_stream::GStreamerMediaStream;
 use mime::Mime;
@@ -44,9 +44,8 @@ use std::sync::{Arc, Mutex, Weak};
 use std::thread;
 use std::vec::Vec;
 
-static BACKEND_BASE_TIME: Lazy<gst::ClockTime> = Lazy::new(|| {
-    gst::SystemClock::obtain().time().unwrap()
-});
+static BACKEND_BASE_TIME: Lazy<gst::ClockTime> =
+    Lazy::new(|| gst::SystemClock::obtain().time().unwrap());
 
 static BACKEND_THREAD: OnceCell<bool> = OnceCell::new();
 

--- a/backends/gstreamer/lib.rs
+++ b/backends/gstreamer/lib.rs
@@ -15,7 +15,7 @@ pub mod webrtc;
 use device_monitor::GStreamerDeviceMonitor;
 use gst::prelude::*;
 use ipc_channel::ipc::IpcSender;
-use lazy_static::lazy_static;
+use glib::once_cell::sync::Lazy;
 use log::warn;
 use media_stream::GStreamerMediaStream;
 use mime::Mime;
@@ -44,9 +44,9 @@ use std::sync::{Arc, Mutex, Weak};
 use std::thread;
 use std::vec::Vec;
 
-lazy_static! {
-    static ref BACKEND_BASE_TIME: gst::ClockTime = gst::SystemClock::obtain().time().unwrap();
-}
+static BACKEND_BASE_TIME: Lazy<gst::ClockTime> = Lazy::new(|| {
+    gst::SystemClock::obtain().time().unwrap()
+});
 
 static BACKEND_THREAD: OnceCell<bool> = OnceCell::new();
 

--- a/backends/gstreamer/media_stream.rs
+++ b/backends/gstreamer/media_stream.rs
@@ -1,7 +1,7 @@
 use super::BACKEND_BASE_TIME;
 use gst;
 use gst::prelude::*;
-use lazy_static::lazy_static;
+use glib::once_cell::sync::Lazy;
 use servo_media_streams::registry::{
     get_stream, register_stream, unregister_stream, MediaStreamId,
 };
@@ -9,20 +9,19 @@ use servo_media_streams::{MediaOutput, MediaSocket, MediaStream, MediaStreamType
 use std::any::Any;
 use std::sync::{Arc, Mutex};
 
-lazy_static! {
-    pub static ref RTP_CAPS_OPUS: gst::Caps = {
-        gst::Caps::builder("application/x-rtp")
-            .field("media", "audio")
-            .field("encoding-name", "OPUS")
-            .build()
-    };
-    pub static ref RTP_CAPS_VP8: gst::Caps = {
-        gst::Caps::builder("application/x-rtp")
-            .field("media", "video")
-            .field("encoding-name", "VP8")
-            .build()
-    };
-}
+pub static RTP_CAPS_OPUS: Lazy<gst::Caps> = Lazy::new(|| {
+    gst::Caps::builder("application/x-rtp")
+        .field("media", "audio")
+        .field("encoding-name", "OPUS")
+        .build()
+});
+
+pub static RTP_CAPS_VP8: Lazy<gst::Caps> = Lazy::new(|| {
+    gst::Caps::builder("application/x-rtp")
+        .field("media", "video")
+        .field("encoding-name", "VP8")
+        .build()
+});
 
 pub struct GStreamerMediaStream {
     id: Option<MediaStreamId>,

--- a/backends/gstreamer/media_stream.rs
+++ b/backends/gstreamer/media_stream.rs
@@ -99,7 +99,7 @@ impl GStreamerMediaStream {
         if let Some(ref pipeline) = self.pipeline {
             pipeline.clone()
         } else {
-            let pipeline = gst::Pipeline::new(Some("gstreamermediastream fresh pipeline"));
+            let pipeline = gst::Pipeline::with_name("gstreamermediastream fresh pipeline");
             let clock = gst::SystemClock::obtain();
             pipeline.set_start_time(gst::ClockTime::NONE);
             pipeline.set_base_time(*BACKEND_BASE_TIME);

--- a/backends/gstreamer/media_stream.rs
+++ b/backends/gstreamer/media_stream.rs
@@ -1,7 +1,7 @@
 use super::BACKEND_BASE_TIME;
-use glib::prelude::*;
 use gst;
 use gst::prelude::*;
+use lazy_static::lazy_static;
 use servo_media_streams::registry::{
     get_stream, register_stream, unregister_stream, MediaStreamId,
 };
@@ -11,16 +11,16 @@ use std::sync::{Arc, Mutex};
 
 lazy_static! {
     pub static ref RTP_CAPS_OPUS: gst::Caps = {
-        gst::Caps::new_simple(
-            "application/x-rtp",
-            &[("media", &"audio"), ("encoding-name", &"OPUS")],
-        )
+        gst::Caps::builder("application/x-rtp")
+            .field("media", "audio")
+            .field("encoding-name", "OPUS")
+            .build()
     };
     pub static ref RTP_CAPS_VP8: gst::Caps = {
-        gst::Caps::new_simple(
-            "application/x-rtp",
-            &[("media", &"video"), ("encoding-name", &"VP8")],
-        )
+        gst::Caps::builder("application/x-rtp")
+            .field("media", "video")
+            .field("encoding-name", "VP8")
+            .build()
     };
 }
 
@@ -61,29 +61,23 @@ impl GStreamerMediaStream {
 
     pub fn caps(&self) -> &gst::Caps {
         match self.type_ {
-            MediaStreamType::Audio => &*RTP_CAPS_OPUS,
-            MediaStreamType::Video => &*RTP_CAPS_VP8,
+            MediaStreamType::Audio => &RTP_CAPS_OPUS,
+            MediaStreamType::Video => &RTP_CAPS_VP8,
         }
     }
 
     pub fn caps_with_payload(&self, payload: i32) -> gst::Caps {
         match self.type_ {
-            MediaStreamType::Audio => gst::Caps::new_simple(
-                "application/x-rtp",
-                &[
-                    ("media", &"audio"),
-                    ("encoding-name", &"OPUS"),
-                    ("payload", &(payload)),
-                ],
-            ),
-            MediaStreamType::Video => gst::Caps::new_simple(
-                "application/x-rtp",
-                &[
-                    ("media", &"video"),
-                    ("encoding-name", &"VP8"),
-                    ("payload", &(payload)),
-                ],
-            ),
+            MediaStreamType::Audio => gst::Caps::builder("application/x-rtp")
+                .field("media", "audio")
+                .field("encoding-name", "OPUS")
+                .field("payload", payload)
+                .build(),
+            MediaStreamType::Video => gst::Caps::builder("application/x-rtp")
+                .field("media", "video")
+                .field("encoding-name", "VP8")
+                .field("payload", payload)
+                .build(),
         }
     }
 
@@ -108,7 +102,7 @@ impl GStreamerMediaStream {
         } else {
             let pipeline = gst::Pipeline::new(Some("gstreamermediastream fresh pipeline"));
             let clock = gst::SystemClock::obtain();
-            pipeline.set_start_time(gst::ClockTime::none());
+            pipeline.set_start_time(gst::ClockTime::NONE);
             pipeline.set_base_time(*BACKEND_BASE_TIME);
             pipeline.use_clock(Some(&clock));
             self.attach_to_pipeline(&pipeline);
@@ -117,12 +111,11 @@ impl GStreamerMediaStream {
     }
 
     pub fn create_video() -> MediaStreamId {
-        let videotestsrc = gst::ElementFactory::make("videotestsrc", None).unwrap();
-        videotestsrc.set_property_from_str("pattern", "ball");
-        videotestsrc
-            .set_property("is-live", &true)
-            .expect("videotestsrc doesn't have expected 'is-live' property");
-
+        let videotestsrc = gst::ElementFactory::make("videotestsrc")
+            .property_from_str("pattern", "ball")
+            .property("is-live", true)
+            .build()
+            .unwrap();
         Self::create_video_from(videotestsrc)
     }
 
@@ -134,17 +127,19 @@ impl GStreamerMediaStream {
             .expect("GStreamerMediaStream::encoded() should not be called without a pipeline");
         let src = self.src_element();
 
-        let capsfilter = gst::ElementFactory::make("capsfilter", None).unwrap();
-        capsfilter.set_property("caps", self.caps()).unwrap();
+        let capsfilter = gst::ElementFactory::make("capsfilter")
+            .property("caps", self.caps())
+            .build()
+            .unwrap();
         match self.type_ {
             MediaStreamType::Video => {
-                let vp8enc = gst::ElementFactory::make("vp8enc", None).unwrap();
-                vp8enc
-                    .set_property("deadline", &1i64)
-                    .expect("vp8enc doesn't have expected 'deadline' property");
+                let vp8enc = gst::ElementFactory::make("vp8enc")
+                    .property("deadline", 1i64)
+                    .build()
+                    .unwrap();
 
-                let rtpvp8pay = gst::ElementFactory::make("rtpvp8pay", None).unwrap();
-                let queue2 = gst::ElementFactory::make("queue", None).unwrap();
+                let rtpvp8pay = gst::ElementFactory::make("rtpvp8pay").build().unwrap();
+                let queue2 = gst::ElementFactory::make("queue").build().unwrap();
 
                 pipeline
                     .add_many(&[&vp8enc, &rtpvp8pay, &queue2, &capsfilter])
@@ -158,9 +153,9 @@ impl GStreamerMediaStream {
                 capsfilter
             }
             MediaStreamType::Audio => {
-                let opusenc = gst::ElementFactory::make("opusenc", None).unwrap();
-                let rtpopuspay = gst::ElementFactory::make("rtpopuspay", None).unwrap();
-                let queue3 = gst::ElementFactory::make("queue", None).unwrap();
+                let opusenc = gst::ElementFactory::make("opusenc").build().unwrap();
+                let rtpopuspay = gst::ElementFactory::make("rtpopuspay").build().unwrap();
+                let queue3 = gst::ElementFactory::make("queue").build().unwrap();
                 pipeline
                     .add_many(&[&opusenc, &rtpopuspay, &queue3, &capsfilter])
                     .unwrap();
@@ -175,8 +170,8 @@ impl GStreamerMediaStream {
     }
 
     pub fn create_video_from(source: gst::Element) -> MediaStreamId {
-        let videoconvert = gst::ElementFactory::make("videoconvert", None).unwrap();
-        let queue = gst::ElementFactory::make("queue", None).unwrap();
+        let videoconvert = gst::ElementFactory::make("videoconvert").build().unwrap();
+        let queue = gst::ElementFactory::make("queue").build().unwrap();
 
         register_stream(Arc::new(Mutex::new(GStreamerMediaStream::new(
             MediaStreamType::Video,
@@ -185,20 +180,20 @@ impl GStreamerMediaStream {
     }
 
     pub fn create_audio() -> MediaStreamId {
-        let audiotestsrc = gst::ElementFactory::make("audiotestsrc", None).unwrap();
-        audiotestsrc.set_property_from_str("wave", "sine");
-        audiotestsrc
-            .set_property("is-live", &true)
-            .expect("audiotestsrc doesn't have expected 'is-live' property");
+        let audiotestsrc = gst::ElementFactory::make("audiotestsrc")
+            .property_from_str("wave", "sine")
+            .property("is-live", true)
+            .build()
+            .unwrap();
 
         Self::create_audio_from(audiotestsrc)
     }
 
     pub fn create_audio_from(source: gst::Element) -> MediaStreamId {
-        let queue = gst::ElementFactory::make("queue", None).unwrap();
-        let audioconvert = gst::ElementFactory::make("audioconvert", None).unwrap();
-        let audioresample = gst::ElementFactory::make("audioresample", None).unwrap();
-        let queue2 = gst::ElementFactory::make("queue", None).unwrap();
+        let queue = gst::ElementFactory::make("queue").build().unwrap();
+        let audioconvert = gst::ElementFactory::make("audioconvert").build().unwrap();
+        let audioresample = gst::ElementFactory::make("audioresample").build().unwrap();
+        let queue2 = gst::ElementFactory::make("queue").build().unwrap();
 
         register_stream(Arc::new(Mutex::new(GStreamerMediaStream::new(
             MediaStreamType::Audio,
@@ -207,9 +202,11 @@ impl GStreamerMediaStream {
     }
 
     pub fn create_proxy(ty: MediaStreamType) -> (MediaStreamId, GstreamerMediaSocket) {
-        let proxy_src = gst::ElementFactory::make("proxysrc", None).unwrap();
-        let proxy_sink = gst::ElementFactory::make("proxysink", None).unwrap();
-        proxy_src.set_property("proxysink", &proxy_sink).unwrap();
+        let proxy_sink = gst::ElementFactory::make("proxysink").build().unwrap();
+        let proxy_src = gst::ElementFactory::make("proxysrc")
+            .property("proxysink", &proxy_sink)
+            .build()
+            .unwrap();
         let stream = match ty {
             MediaStreamType::Audio => Self::create_audio_from(proxy_src),
             MediaStreamType::Video => Self::create_video_from(proxy_src),
@@ -239,7 +236,7 @@ impl MediaSink {
 
 impl MediaOutput for MediaSink {
     fn add_stream(&mut self, stream: &MediaStreamId) {
-        let stream = get_stream(&stream).expect("Media streams registry does not contain such ID");
+        let stream = get_stream(stream).expect("Media streams registry does not contain such ID");
         {
             let mut stream = stream.lock().unwrap();
             let stream = stream
@@ -253,7 +250,7 @@ impl MediaOutput for MediaSink {
                 MediaStreamType::Audio => "autoaudiosink",
                 MediaStreamType::Video => "autovideosink",
             };
-            let sink = gst::ElementFactory::make(sink, None).unwrap();
+            let sink = gst::ElementFactory::make(sink).build().unwrap();
             pipeline.add(&sink).unwrap();
             gst::Element::link_many(&[last_element, &sink][..]).unwrap();
 

--- a/backends/gstreamer/media_stream_source.rs
+++ b/backends/gstreamer/media_stream_source.rs
@@ -4,7 +4,6 @@ use glib::subclass::prelude::*;
 use gst::prelude::*;
 use gst::subclass::prelude::*;
 use gst_base::UniqueFlowCombiner;
-use lazy_static::lazy_static;
 use servo_media_streams::{MediaStream, MediaStreamType};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -14,26 +13,25 @@ use url::Url;
 mod imp {
     use super::*;
 
-    lazy_static! {
-        static ref AUDIO_SRC_PAD_TEMPLATE: gst::PadTemplate = {
-            gst::PadTemplate::new(
-                "audio_src",
-                gst::PadDirection::Src,
-                gst::PadPresence::Sometimes,
-                &RTP_CAPS_OPUS,
-            )
-            .expect("Could not create audio src pad template")
-        };
-        static ref VIDEO_SRC_PAD_TEMPLATE: gst::PadTemplate = {
-            gst::PadTemplate::new(
-                "video_src",
-                gst::PadDirection::Src,
-                gst::PadPresence::Sometimes,
-                &RTP_CAPS_VP8,
-            )
-            .expect("Could not create video src pad template")
-        };
-    }
+    static AUDIO_SRC_PAD_TEMPLATE: Lazy<gst::PadTemplate> = Lazy::new(|| {
+        gst::PadTemplate::new(
+            "audio_src",
+            gst::PadDirection::Src,
+            gst::PadPresence::Sometimes,
+            &RTP_CAPS_OPUS,
+        )
+        .expect("Could not create audio src pad template")
+    });
+
+    static VIDEO_SRC_PAD_TEMPLATE: Lazy<gst::PadTemplate> = Lazy::new(|| {
+        gst::PadTemplate::new(
+            "video_src",
+            gst::PadDirection::Src,
+            gst::PadPresence::Sometimes,
+            &RTP_CAPS_VP8,
+        )
+        .expect("Could not create video src pad template")
+    });
 
     pub struct ServoMediaStreamSrc {
         cat: gst::DebugCategory,

--- a/backends/gstreamer/media_stream_source.rs
+++ b/backends/gstreamer/media_stream_source.rs
@@ -1,12 +1,10 @@
-use glib;
-use glib::subclass;
+use crate::media_stream::{GStreamerMediaStream, RTP_CAPS_OPUS, RTP_CAPS_VP8};
+use glib::once_cell::sync::Lazy;
 use glib::subclass::prelude::*;
-use glib::translate::*;
-use gst;
 use gst::prelude::*;
 use gst::subclass::prelude::*;
 use gst_base::UniqueFlowCombiner;
-use media_stream::{GStreamerMediaStream, RTP_CAPS_OPUS, RTP_CAPS_VP8};
+use lazy_static::lazy_static;
 use servo_media_streams::{MediaStream, MediaStreamType};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -61,12 +59,12 @@ mod imp {
             // likely involves encoding and muxing all streams of the same type
             // in a single stream.
 
-            gst_log!(self.cat, "Setting stream");
+            gst::log!(self.cat, "Setting stream");
 
             // Append a proxysink to the media stream pipeline.
             let pipeline = stream.pipeline_or_new();
             let last_element = stream.encoded();
-            let sink = gst::ElementFactory::make("proxysink", None).unwrap();
+            let sink = gst::ElementFactory::make("proxysink").build().unwrap();
             pipeline.add(&sink).unwrap();
             gst::Element::link_many(&[&last_element, &sink][..]).unwrap();
 
@@ -104,9 +102,7 @@ mod imp {
                     )
                 }
             };
-            proxysrc
-                .set_property("proxysink", &sink)
-                .expect("Could not set proxysink property on proxysrc");
+            proxysrc.set_property("proxysink", sink);
 
             // Add proxysrc to bin
             let bin = src.downcast_ref::<gst::Bin>().unwrap();
@@ -114,7 +110,7 @@ mod imp {
                 .expect("Could not add proxysrc element to bin");
 
             let target_pad = proxysrc
-                .get_static_pad("src")
+                .static_pad("src")
                 .expect("Could not get proxysrc's static src pad");
             src_pad
                 .set_target(Some(&target_pad))
@@ -122,20 +118,11 @@ mod imp {
 
             src.add_pad(src_pad)
                 .expect("Could not add source pad to media stream src");
-            ::set_element_flags(src, gst::ElementFlags::SOURCE);
+            src.set_element_flags(gst::ElementFlags::SOURCE);
 
-            let proxy_pad = src_pad.get_internal().unwrap();
+            let proxy_pad = src_pad.internal().unwrap();
             src_pad.set_active(true).expect("Could not active pad");
             self.flow_combiner.lock().unwrap().add_pad(&proxy_pad);
-            let combiner = self.flow_combiner.clone();
-            proxy_pad.set_chain_function(move |pad, parent, buffer| {
-                let chain_result = pad.proxy_pad_chain_default(parent, buffer);
-                let result = combiner.lock().unwrap().update_pad_flow(pad, chain_result);
-                if result == Err(gst::FlowError::Flushing) {
-                    return chain_result;
-                }
-                result
-            });
 
             src.sync_state_with_parent().unwrap();
 
@@ -146,32 +133,57 @@ mod imp {
     }
 
     // Basic declaration of our type for the GObject type system.
+    #[glib::object_subclass]
     impl ObjectSubclass for ServoMediaStreamSrc {
         const NAME: &'static str = "ServoMediaStreamSrc";
+        type Type = super::ServoMediaStreamSrc;
         type ParentType = gst::Bin;
-        type Instance = gst::subclass::ElementInstanceStruct<Self>;
-        type Class = subclass::simple::ClassStruct<Self>;
-
-        glib_object_subclass!();
+        type Interfaces = (gst::URIHandler,);
 
         // Called once at the very beginning of instantiation of each instance and
         // creates the data structure that contains all our state
-        fn new_with_class(_: &subclass::simple::ClassStruct<Self>) -> Self {
-            let audio_proxysrc = gst::ElementFactory::make("proxysrc", None)
-                .expect("Could not create proxysrc element");
-            let audio_srcpad = gst::GhostPad::new_no_target_from_template(
-                Some("audio_src"),
-                &AUDIO_SRC_PAD_TEMPLATE,
-            )
-            .unwrap();
+        fn with_class(_klass: &Self::Class) -> Self {
+            let flow_combiner = Arc::new(Mutex::new(UniqueFlowCombiner::new()));
 
-            let video_proxysrc = gst::ElementFactory::make("proxysrc", None)
+            fn create_ghost_pad_with_template(
+                name: &str,
+                pad_template: &gst::PadTemplate,
+                flow_combiner: Arc<Mutex<UniqueFlowCombiner>>,
+            ) -> gst::GhostPad {
+                gst::GhostPad::builder_with_template(pad_template, Some(name))
+                    .chain_function({
+                        move |pad, parent, buffer| {
+                            let chain_result = gst::ProxyPad::chain_default(pad, parent, buffer);
+                            let result = flow_combiner
+                                .lock()
+                                .unwrap()
+                                .update_pad_flow(pad, chain_result);
+                            if result == Err(gst::FlowError::Flushing) {
+                                return chain_result;
+                            }
+                            result
+                        }
+                    })
+                    .build()
+            }
+
+            let audio_proxysrc = gst::ElementFactory::make("proxysrc")
+                .build()
                 .expect("Could not create proxysrc element");
-            let video_srcpad = gst::GhostPad::new_no_target_from_template(
-                Some("video_src"),
+            let audio_srcpad = create_ghost_pad_with_template(
+                "audio_src",
+                &AUDIO_SRC_PAD_TEMPLATE,
+                flow_combiner.clone(),
+            );
+
+            let video_proxysrc = gst::ElementFactory::make("proxysrc")
+                .build()
+                .expect("Could not create proxysrc element");
+            let video_srcpad = create_ghost_pad_with_template(
+                "video_src",
                 &VIDEO_SRC_PAD_TEMPLATE,
-            )
-            .unwrap();
+                flow_combiner.clone(),
+            );
 
             Self {
                 cat: gst::DebugCategory::new(
@@ -183,46 +195,10 @@ mod imp {
                 audio_srcpad,
                 video_proxysrc,
                 video_srcpad,
-                flow_combiner: Arc::new(Mutex::new(UniqueFlowCombiner::new())),
+                flow_combiner,
                 has_video_stream: Arc::new(AtomicBool::new(false)),
                 has_audio_stream: Arc::new(AtomicBool::new(false)),
             }
-        }
-
-        // Adds interface implementations in the class
-        fn type_init(type_: &mut subclass::InitializingType<Self>) {
-            type_.add_interface::<gst::URIHandler>();
-        }
-
-        // Called exactly once before the first instantiation of an instance. This
-        // sets up any type-specific things, in this specific case it installs the
-        // properties so that GObject knows about their existence and they can be
-        // used on instances of our type
-        fn class_init(klass: &mut subclass::simple::ClassStruct<Self>) {
-            klass.set_metadata(
-                "Servo Media Stream Source",
-                "Source/Audio/Video",
-                "Feed player with media stream data",
-                "Servo developers",
-            );
-
-            // Let playbin3 know we are a live source.
-            klass.install_properties(&[subclass::Property("is-live", |name| {
-                glib::ParamSpec::boolean(
-                    name,
-                    "Is Live",
-                    "Let playbin3 know we are a live source",
-                    true,
-                    glib::ParamFlags::READWRITE,
-                )
-            })]);
-
-            // Add pad templates for our audio and video source pads.
-            // These are later used for actually creating the pads and beforehand
-            // already provide information to GStreamer about all possible
-            // pads that could exist for this type.
-            klass.add_pad_template(AUDIO_SRC_PAD_TEMPLATE.clone());
-            klass.add_pad_template(VIDEO_SRC_PAD_TEMPLATE.clone());
         }
     }
 
@@ -233,29 +209,78 @@ mod imp {
     // This maps between the GObject properties and our internal storage of the
     // corresponding values of the properties.
     impl ObjectImpl for ServoMediaStreamSrc {
-        glib_object_impl!();
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![
+                    // Let playbin3 know we are a live source.
+                    glib::ParamSpecBoolean::builder("is-live")
+                        .nick("Is Live")
+                        .blurb("Let playbin3 know we are a live source")
+                        .default_value(true)
+                        .readwrite()
+                        .build(),
+                ]
+            });
 
-        fn get_property(&self, _: &glib::Object, id: usize) -> Result<glib::Value, ()> {
-            // We have a single property: is-live
-            if id != 0 {
-                return Err(());
+            &PROPERTIES
+        }
+
+        fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "is-live" => true.to_value(),
+                _ => unimplemented!(),
             }
-            Ok(true.to_value())
         }
     }
 
+    impl GstObjectImpl for ServoMediaStreamSrc {}
+
     // Implementation of gst::Element virtual methods
-    impl ElementImpl for ServoMediaStreamSrc {}
+    impl ElementImpl for ServoMediaStreamSrc {
+        fn metadata() -> Option<&'static gst::subclass::ElementMetadata> {
+            static ELEMENT_METADATA: Lazy<gst::subclass::ElementMetadata> = Lazy::new(|| {
+                gst::subclass::ElementMetadata::new(
+                    "Servo Media Stream Source",
+                    "Source/Audio/Video",
+                    "Feed player with media stream data",
+                    "Servo developers",
+                )
+            });
+
+            Some(&*ELEMENT_METADATA)
+        }
+
+        fn pad_templates() -> &'static [gst::PadTemplate] {
+            static PAD_TEMPLATES: Lazy<Vec<gst::PadTemplate>> = Lazy::new(|| {
+                // Add pad templates for our audio and video source pads.
+                // These are later used for actually creating the pads and beforehand
+                // already provide information to GStreamer about all possible
+                // pads that could exist for this type.
+                vec![
+                    AUDIO_SRC_PAD_TEMPLATE.clone(),
+                    VIDEO_SRC_PAD_TEMPLATE.clone(),
+                ]
+            });
+
+            PAD_TEMPLATES.as_ref()
+        }
+    }
 
     // Implementation of gst::Bin virtual methods
     impl BinImpl for ServoMediaStreamSrc {}
 
     impl URIHandlerImpl for ServoMediaStreamSrc {
-        fn get_uri(&self, _element: &gst::URIHandler) -> Option<String> {
+        const URI_TYPE: gst::URIType = gst::URIType::Src;
+
+        fn protocols() -> &'static [&'static str] {
+            &["mediastream"]
+        }
+
+        fn uri(&self) -> Option<String> {
             Some("mediastream://".to_string())
         }
 
-        fn set_uri(&self, _element: &gst::URIHandler, uri: &str) -> Result<(), glib::Error> {
+        fn set_uri(&self, uri: &str) -> Result<(), glib::Error> {
             if let Ok(uri) = Url::parse(uri) {
                 if uri.scheme() == "mediastream" {
                     return Ok(());
@@ -266,27 +291,14 @@ mod imp {
                 format!("Invalid URI '{:?}'", uri,).as_str(),
             ))
         }
-
-        fn get_uri_type() -> gst::URIType {
-            gst::URIType::Src
-        }
-
-        fn get_protocols() -> Vec<String> {
-            vec!["mediastream".into()]
-        }
     }
 }
 
 // Public part of the ServoMediaStreamSrc type. This behaves like a normal
 // GObject binding
-glib_wrapper! {
-    pub struct ServoMediaStreamSrc(Object<gst::subclass::ElementInstanceStruct<imp::ServoMediaStreamSrc>,
-                                   subclass::simple::ClassStruct<imp::ServoMediaStreamSrc>, ServoMediaStreamSrcClass>)
+glib::wrapper! {
+    pub struct ServoMediaStreamSrc(ObjectSubclass<imp::ServoMediaStreamSrc>)
         @extends gst::Bin, gst::Element, gst::Object, @implements gst::URIHandler;
-
-    match fn {
-        get_type => || imp::ServoMediaStreamSrc::get_type().to_glib(),
-    }
 }
 
 unsafe impl Send for ServoMediaStreamSrc {}
@@ -294,11 +306,8 @@ unsafe impl Sync for ServoMediaStreamSrc {}
 
 impl ServoMediaStreamSrc {
     pub fn set_stream(&self, stream: &mut GStreamerMediaStream, only_stream: bool) {
-        imp::ServoMediaStreamSrc::from_instance(self).set_stream(
-            stream,
-            self.upcast_ref::<gst::Element>(),
-            only_stream,
-        )
+        self.imp()
+            .set_stream(stream, self.upcast_ref::<gst::Element>(), only_stream)
     }
 }
 

--- a/backends/gstreamer/media_stream_source.rs
+++ b/backends/gstreamer/media_stream_source.rs
@@ -148,7 +148,8 @@ mod imp {
                 pad_template: &gst::PadTemplate,
                 flow_combiner: Arc<Mutex<UniqueFlowCombiner>>,
             ) -> gst::GhostPad {
-                gst::GhostPad::builder_with_template(pad_template, Some(name))
+                gst::GhostPad::builder_from_template(pad_template)
+                    .name(name)
                     .chain_function({
                         move |pad, parent, buffer| {
                             let chain_result = gst::ProxyPad::chain_default(pad, parent, buffer);

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -424,7 +424,7 @@ impl GStreamerPlayer {
             // player store the downloaded media in a local temporary file for
             // faster playback of already-downloaded chunks.
             let flags = pipeline.property_value("flags");
-            let flags_class = match glib::FlagsClass::new(flags.type_()) {
+            let flags_class = match glib::FlagsClass::with_type(flags.type_()) {
                 Some(flags) => flags,
                 None => {
                     return Err(PlayerError::Backend(

--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -1,4 +1,8 @@
 use super::BACKEND_BASE_TIME;
+use crate::media_stream::GStreamerMediaStream;
+use crate::media_stream_source::{register_servo_media_stream_src, ServoMediaStreamSrc};
+use crate::render::GStreamerRender;
+use crate::source::{register_servo_src, ServoSrc};
 use byte_slice_cast::AsSliceOf;
 use glib;
 use glib::prelude::*;
@@ -8,9 +12,6 @@ use gst_app;
 use gst_player;
 use gst_player::prelude::*;
 use ipc_channel::ipc::{channel, IpcReceiver, IpcSender};
-use media_stream::GStreamerMediaStream;
-use media_stream_source::{register_servo_media_stream_src, ServoMediaStreamSrc};
-use render::GStreamerRender;
 use servo_media_player::audio::AudioRenderer;
 use servo_media_player::context::PlayerGLContext;
 use servo_media_player::metadata::Metadata;
@@ -20,7 +21,6 @@ use servo_media_player::{
 };
 use servo_media_streams::registry::{get_stream, MediaStreamId};
 use servo_media_traits::{BackendMsg, ClientContextId, MediaInstance};
-use source::{register_servo_src, ServoSrc};
 use std::cell::RefCell;
 use std::ops::Range;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -32,11 +32,11 @@ use std::u64;
 const MAX_BUFFER_SIZE: i32 = 500 * 1024 * 1024;
 
 fn metadata_from_media_info(media_info: &gst_player::PlayerMediaInfo) -> Result<Metadata, ()> {
-    let dur = media_info.get_duration();
-    let duration = if dur != gst::ClockTime::none() {
-        let mut nanos = dur.nanoseconds().ok_or_else(|| ())?;
+    let dur = media_info.duration();
+    let duration = if let Some(dur) = dur {
+        let mut nanos = dur.nseconds();
         nanos = nanos % 1_000_000_000;
-        let seconds = dur.seconds().ok_or_else(|| ())?;
+        let seconds = dur.seconds();
         Some(time::Duration::new(seconds, nanos as u32))
     } else {
         None
@@ -46,23 +46,23 @@ fn metadata_from_media_info(media_info: &gst_player::PlayerMediaInfo) -> Result<
     let mut video_tracks = Vec::new();
 
     let format = media_info
-        .get_container_format()
+        .container_format()
         .unwrap_or_else(|| glib::GString::from(""))
         .to_string();
 
-    for stream_info in media_info.get_stream_list() {
-        let stream_type = stream_info.get_stream_type();
+    for stream_info in media_info.stream_list() {
+        let stream_type = stream_info.stream_type();
         match stream_type.as_str() {
             "audio" => {
                 let codec = stream_info
-                    .get_codec()
+                    .codec()
                     .unwrap_or_else(|| glib::GString::from(""))
                     .to_string();
                 audio_tracks.push(codec);
             }
             "video" => {
                 let codec = stream_info
-                    .get_codec()
+                    .codec()
                     .unwrap_or_else(|| glib::GString::from(""))
                     .to_string();
                 video_tracks.push(codec);
@@ -72,17 +72,17 @@ fn metadata_from_media_info(media_info: &gst_player::PlayerMediaInfo) -> Result<
     }
 
     let mut width: u32 = 0;
-    let height: u32 = if media_info.get_number_of_video_streams() > 0 {
-        let first_video_stream = &media_info.get_video_streams()[0];
-        width = first_video_stream.get_width() as u32;
-        first_video_stream.get_height() as u32
+    let height: u32 = if media_info.number_of_video_streams() > 0 {
+        let first_video_stream = &media_info.video_streams()[0];
+        width = first_video_stream.width() as u32;
+        first_video_stream.height() as u32
     } else {
         0
     };
 
     let is_seekable = media_info.is_seekable();
     let is_live = media_info.is_live();
-    let title = media_info.get_title().map(|s| s.as_str().to_string());
+    let title = media_info.title().map(|s| s.as_str().to_string());
 
     Ok(Metadata {
         duration,
@@ -154,7 +154,7 @@ impl PlayerInner {
         self.rate = rate;
         if let Some(ref metadata) = self.last_metadata {
             if !metadata.is_seekable {
-                gst_warning!(self.cat, obj: &self.player,
+                gst::warning!(self.cat, obj: &self.player,
                              "Player must be seekable in order to set the playback rate");
                 return Err(PlayerError::NonSeekableStream);
             }
@@ -185,7 +185,7 @@ impl PlayerInner {
             Some(ref mut source) => {
                 if let PlayerSource::Seekable(source) = source {
                     source
-                        .end_of_stream()
+                        .push_end_of_stream()
                         .map(|_| ())
                         .map_err(|_| PlayerError::EOSFailed)
                 } else {
@@ -203,7 +203,7 @@ impl PlayerInner {
         if let Some(ref metadata) = self.last_metadata {
             if let Some(ref duration) = metadata.duration {
                 if duration < &time::Duration::new(time as u64, 0) {
-                    gst_warning!(self.cat, obj: &self.player, "Trying to seek out of range");
+                    gst::warning!(self.cat, obj: &self.player, "Trying to seek out of range");
                     return Err(PlayerError::SeekOutOfRange);
                 }
             }
@@ -242,25 +242,23 @@ impl PlayerInner {
         let mut result = vec![];
         if let Some(ref metadata) = self.last_metadata {
             if let Some(ref duration) = metadata.duration {
-                let pipeline = self.player.get_pipeline();
-                let mut buffering = gst::Query::new_buffering(gst::Format::Percent);
+                let pipeline = self.player.pipeline();
+                let mut buffering = gst::query::Buffering::new(gst::Format::Percent);
                 if pipeline.query(&mut buffering) {
-                    let ranges = buffering.get_ranges();
-                    for i in 0..ranges.len() {
-                        let start = ranges[i].0;
-                        let end = ranges[i].1;
+                    let ranges = buffering.ranges();
+                    for (start, end) in &ranges {
                         let start = (if let gst::GenericFormattedValue::Percent(start) = start {
                             start.unwrap()
                         } else {
-                            0
+                            gst::format::Percent::from_percent(0)
                         } * duration.as_secs() as u32
-                            / (gst::FORMAT_PERCENT_MAX)) as f64;
+                            / gst::format::Percent::MAX) as f64;
                         let end = (if let gst::GenericFormattedValue::Percent(end) = end {
                             end.unwrap()
                         } else {
-                            0
+                            gst::format::Percent::from_percent(0)
                         } * duration.as_secs() as u32
-                            / (gst::FORMAT_PERCENT_MAX)) as f64;
+                            / gst::format::Percent::MAX) as f64;
                         result.push(Range { start, end });
                     }
                 }
@@ -280,12 +278,12 @@ impl PlayerInner {
                 {
                     let playbin = self
                         .player
-                        .get_pipeline()
+                        .pipeline()
                         .dynamic_cast::<gst::Pipeline>()
                         .unwrap();
                     let clock = gst::SystemClock::obtain();
                     playbin.set_base_time(*BACKEND_BASE_TIME);
-                    playbin.set_start_time(gst::ClockTime::none());
+                    playbin.set_start_time(gst::ClockTime::NONE);
                     playbin.use_clock(Some(&clock));
 
                     source.set_stream(&mut stream, only_stream);
@@ -417,20 +415,15 @@ impl GStreamerPlayer {
             }
         }
 
-        let player = gst_player::Player::new(
-            /* video renderer */ None, /* signal dispatcher */ None,
-        );
-
-        let pipeline = player.get_pipeline();
+        let player = gst_player::Player::default();
+        let pipeline = player.pipeline();
 
         // FIXME(#282): The progressive downloading breaks playback on Windows and Android.
         if !cfg!(any(target_os = "windows", target_os = "android")) {
             // Set player to perform progressive downloading. This will make the
             // player store the downloaded media in a local temporary file for
             // faster playback of already-downloaded chunks.
-            let flags = pipeline
-                .get_property("flags")
-                .expect("playbin doesn't have expected 'flags' property");
+            let flags = pipeline.property_value("flags");
             let flags_class = match glib::FlagsClass::new(flags.type_()) {
                 Some(flags) => flags,
                 None => {
@@ -447,49 +440,41 @@ impl GStreamerPlayer {
                     ));
                 }
             };
-            let flags = match flags_class.set_by_nick("download").build() {
-                Some(flags) => flags,
-                None => {
-                    return Err(PlayerError::Backend(
-                        "FlagsClass creation failed".to_owned(),
-                    ));
-                }
+            let Some(flags) = flags_class.set_by_nick("download").build() else {
+                return Err(PlayerError::Backend(
+                    "FlagsClass creation failed".to_owned(),
+                ));
             };
-            pipeline
-                .set_property("flags", &flags)
-                .expect("playbin doesn't have expected 'flags' property");
+            pipeline.set_property_from_value("flags", &flags);
         }
 
         // Set max size for the player buffer.
-        pipeline
-            .set_property("buffer-size", &MAX_BUFFER_SIZE)
-            .expect("playbin doesn't have expected 'buffer-size' property");
+        pipeline.set_property("buffer-size", MAX_BUFFER_SIZE);
 
         // Set player position interval update to 0.5 seconds.
-        let mut config = player.get_config();
+        let mut config = player.config();
         config.set_position_update_interval(500u32);
         player
             .set_config(config)
             .map_err(|e| PlayerError::Backend(e.to_string()))?;
 
         if let Some(ref audio_renderer) = self.audio_renderer {
-            let audio_sink = gst::ElementFactory::make("appsink", None)
+            let audio_sink = gst::ElementFactory::make("appsink")
+                .build()
                 .map_err(|_| PlayerError::Backend("appsink creation failed".to_owned()))?;
 
-            pipeline
-                .set_property("audio-sink", &audio_sink)
-                .expect("playbin doesn't have expected 'audio-sink' property");
+            pipeline.set_property("audio-sink", &audio_sink);
 
             let audio_sink = audio_sink.dynamic_cast::<gst_app::AppSink>().unwrap();
             let audio_renderer_ = audio_renderer.clone();
             audio_sink.set_callbacks(
-                gst_app::AppSinkCallbacks::new()
+                gst_app::AppSinkCallbacks::builder()
                     .new_preroll(|_| Ok(gst::FlowSuccess::Ok))
                     .new_sample(move |audio_sink| {
                         let sample = audio_sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
-                        let buffer = sample.get_buffer_owned().ok_or(gst::FlowError::Error)?;
+                        let buffer = sample.buffer_owned().ok_or(gst::FlowError::Error)?;
                         let audio_info = sample
-                            .get_caps()
+                            .caps()
                             .and_then(|caps| gst_audio::AudioInfo::from_caps(caps).ok())
                             .ok_or(gst::FlowError::Error)?;
                         let positions = audio_info.positions().ok_or(gst::FlowError::Error)?;
@@ -532,9 +517,7 @@ impl GStreamerPlayer {
                 "servosrc://".to_value()
             }
         };
-        player
-            .set_property("uri", &uri)
-            .expect("playbin doesn't have expected 'uri' property");
+        player.set_property("uri", &uri);
 
         // No video_renderers no video
         if self.video_renderer.is_none() {
@@ -585,7 +568,7 @@ impl GStreamerPlayer {
         let observer = self.observer.clone();
         // Handle `position-update` signal.
         player!(inner).connect_position_updated(move |_, position| {
-            if let Some(seconds) = position.seconds() {
+            if let Some(seconds) = position.map(|p| p.seconds()) {
                 notify!(observer, PlayerEvent::PositionChanged(seconds));
             }
         });
@@ -593,9 +576,7 @@ impl GStreamerPlayer {
         let observer = self.observer.clone();
         // Handle `seek-done` signal.
         player!(inner).connect_seek_done(move |_, position| {
-            if let Some(seconds) = position.seconds() {
-                notify!(observer, PlayerEvent::SeekDone(seconds));
-            }
+            notify!(observer, PlayerEvent::SeekDone(position.seconds()));
         });
 
         // Handle `media-info-updated` signal.
@@ -609,7 +590,7 @@ impl GStreamerPlayer {
                     if metadata.is_seekable {
                         inner.player.set_rate(inner.rate);
                     }
-                    gst_info!(inner.cat, obj: &inner.player, "Metadata updated: {:?}", metadata);
+                    gst::info!(inner.cat, obj: &inner.player, "Metadata updated: {:?}", metadata);
                     notify!(observer, PlayerEvent::MetadataUpdated(metadata));
                 }
             }
@@ -620,36 +601,20 @@ impl GStreamerPlayer {
         let observer = self.observer.clone();
         player!(inner).connect_duration_changed(move |_, duration| {
             let mut inner = inner_clone.lock().unwrap();
-            let duration = if duration != gst::ClockTime::none() {
-                let nanos = duration.nanoseconds();
-                if nanos.is_none() {
-                    gst_info!(inner.cat, obj: &inner.player, "Could not get duration nanoseconds");
-                    return;
-                }
+            let duration = duration.map(|duration| {
+                let nanos = duration.nseconds();
                 let seconds = duration.seconds();
-                if seconds.is_none() {
-                    gst_info!(inner.cat, obj: &inner.player, "Could not get duration seconds");
-                    return;
-                }
-                Some(time::Duration::new(
-                    seconds.unwrap(),
-                    (nanos.unwrap() % 1_000_000_000) as u32,
-                ))
-            } else {
-                None
-            };
+                time::Duration::new(seconds, (nanos % 1_000_000_000) as u32)
+            });
             let mut updated_metadata = None;
             if let Some(ref mut metadata) = inner.last_metadata {
                 metadata.duration = duration;
                 updated_metadata = Some(metadata.clone());
             }
-            if updated_metadata.is_some() {
-                gst_info!(inner.cat, obj: &inner.player, "Duration updated: {:?}",
+            if let Some(updated_metadata) = updated_metadata {
+                gst::info!(inner.cat, obj: &inner.player, "Duration updated: {:?}",
                               updated_metadata);
-                notify!(
-                    observer,
-                    PlayerEvent::MetadataUpdated(updated_metadata.unwrap())
-                );
+                notify!(observer, PlayerEvent::MetadataUpdated(updated_metadata));
             }
         });
 
@@ -658,7 +623,7 @@ impl GStreamerPlayer {
             let observer = self.observer.clone();
             // Set video_sink callbacks.
             inner.lock().unwrap().video_sink.set_callbacks(
-                gst_app::AppSinkCallbacks::new()
+                gst_app::AppSinkCallbacks::builder()
                     .new_preroll(|_| Ok(gst::FlowSuccess::Ok))
                     .new_sample(move |video_sink| {
                         let sample = video_sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
@@ -666,7 +631,7 @@ impl GStreamerPlayer {
                             .lock()
                             .unwrap()
                             .get_frame_from_sample(sample)
-                            .or_else(|_| Err(gst::FlowError::Error))?;
+                            .map_err(|_| gst::FlowError::Error)?;
                         video_renderer.lock().unwrap().render(frame);
                         notify!(observer, PlayerEvent::VideoFrameUpdated);
                         Ok(gst::FlowSuccess::Ok)
@@ -678,7 +643,7 @@ impl GStreamerPlayer {
         let (receiver, error_handler_id) = {
             let inner_clone = inner.clone();
             let mut inner = inner.lock().unwrap();
-            let pipeline = inner.player.get_pipeline();
+            let pipeline = inner.player.pipeline();
 
             let (sender, receiver) = mpsc::channel();
 
@@ -686,23 +651,13 @@ impl GStreamerPlayer {
             let sender_clone = sender.clone();
             let is_ready_clone = self.is_ready.clone();
             let observer = self.observer.clone();
-            let connect_result = pipeline.connect("source-setup", false, move |args| {
-                let source = match args[1].get::<gst::Element>() {
-                    Ok(Some(source)) => source,
-                    _ => {
-                        let _ = notify!(
-                            sender,
-                            Err(PlayerError::Backend("Source setup failed".to_owned()))
-                        );
-                        return None;
-                    }
-                };
+            pipeline.connect("source-setup", false, move |args| {
+                let source = args[1].get::<gst::Element>().unwrap();
 
                 let mut inner = inner_clone.lock().unwrap();
                 let source = match inner.stream_type {
                     StreamType::Seekable => {
                         let servosrc = source
-                            .clone()
                             .dynamic_cast::<ServoSrc>()
                             .expect("Source element is expected to be a ServoSrc!");
 
@@ -720,7 +675,7 @@ impl GStreamerPlayer {
                         let enough_data__ = inner.enough_data.clone();
                         let seek_channel = Arc::new(Mutex::new(SeekChannel::new()));
                         servosrc.set_callbacks(
-                            gst_app::AppSrcCallbacks::new()
+                            gst_app::AppSrcCallbacks::builder()
                                 .need_data(move |_, _| {
                                     // We block the caller of the setup method until we get
                                     // the first need-data signal, so we ensure that we
@@ -767,12 +722,11 @@ impl GStreamerPlayer {
                     }
                     StreamType::Stream => {
                         let media_stream_src = source
-                            .clone()
                             .dynamic_cast::<ServoMediaStreamSrc>()
                             .expect("Source element is expected to be a ServoMediaStreamSrc!");
                         let sender_clone = sender.clone();
                         is_ready_clone.call_once(|| {
-                            let _ = notify!(sender_clone, Ok(()));
+                            notify!(sender_clone, Ok(()));
                         });
                         PlayerSource::Stream(media_stream_src)
                     }
@@ -783,15 +737,8 @@ impl GStreamerPlayer {
                 None
             });
 
-            if connect_result.is_err() {
-                let _ = notify!(
-                    sender_clone,
-                    Err(PlayerError::Backend("Source setup failed".to_owned()))
-                );
-            }
-
             let error_handler_id = inner.player.connect_error(move |player, error| {
-                let _ = notify!(sender_clone, Err(PlayerError::Backend(error.to_string())));
+                notify!(sender_clone, Err(PlayerError::Backend(error.to_string())));
                 player.stop();
             });
 

--- a/backends/gstreamer/registry_scanner.rs
+++ b/backends/gstreamer/registry_scanner.rs
@@ -1,13 +1,12 @@
+use glib::once_cell::sync::Lazy;
 use std::collections::HashSet;
 use std::str::FromStr;
-use glib::once_cell::sync::Lazy;
 
 // The GStreamer registry holds the metadata of the set of plugins available in the host.
 // This scanner is used to lazily analyze the registry and to provide information about
 // the set of supported mime types and codecs that the backend is able to deal with.
-pub static GSTREAMER_REGISTRY_SCANNER: Lazy<GStreamerRegistryScanner> = Lazy::new(|| {
-    GStreamerRegistryScanner::new()
-});
+pub static GSTREAMER_REGISTRY_SCANNER: Lazy<GStreamerRegistryScanner> =
+    Lazy::new(|| GStreamerRegistryScanner::new());
 
 pub struct GStreamerRegistryScanner {
     supported_mime_types: HashSet<&'static str>,

--- a/backends/gstreamer/registry_scanner.rs
+++ b/backends/gstreamer/registry_scanner.rs
@@ -1,14 +1,13 @@
-use lazy_static::lazy_static;
 use std::collections::HashSet;
 use std::str::FromStr;
+use glib::once_cell::sync::Lazy;
 
-lazy_static! {
-    // The GStreamer registry holds the metadata of the set of plugins available in the host.
-    // This scanner is used to lazily analyze the registry and to provide information about
-    // the set of supported mime types and codecs that the backend is able to deal with.
-    pub static ref GSTREAMER_REGISTRY_SCANNER: GStreamerRegistryScanner =
-        GStreamerRegistryScanner::new();
-}
+// The GStreamer registry holds the metadata of the set of plugins available in the host.
+// This scanner is used to lazily analyze the registry and to provide information about
+// the set of supported mime types and codecs that the backend is able to deal with.
+pub static GSTREAMER_REGISTRY_SCANNER: Lazy<GStreamerRegistryScanner> = Lazy::new(|| {
+    GStreamerRegistryScanner::new()
+});
 
 pub struct GStreamerRegistryScanner {
     supported_mime_types: HashSet<&'static str>,

--- a/backends/gstreamer/render-android/Cargo.toml
+++ b/backends/gstreamer/render-android/Cargo.toml
@@ -2,26 +2,34 @@
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
+edition = "2021"
 
 [lib]
 name = "servo_media_gstreamer_render_android"
 path = "lib.rs"
 
 [dependencies.glib]
-version = "0.9"
+version = "0.17"
 
-[dependencies.gstreamer]
-version = "0.15"
+[dependencies.gst]
+package = "gstreamer"
+version = "0.20"
 
-[dependencies.gstreamer-gl]
-version = "0.15"
-features = ["egl"]
+[dependencies.gst-gl]
+package = "gstreamer-gl"
+version = "0.20"
 
-[dependencies.gstreamer-video]
-version = "0.15"
+[dependencies.gstreamer-gl-egl]
+version = "0.20"
 
-[dependencies.servo-media-player]
+[dependencies.gst-video]
+package = "gstreamer-video"
+version = "0.20"
+
+[dependencies.sm-player]
+package = "servo-media-player"
 path = "../../../player"
 
-[dependencies.servo-media-gstreamer-render]
+[dependencies.sm-gst-render]
+package = "servo-media-gstreamer-render"
 path = "../render"

--- a/backends/gstreamer/render-android/Cargo.toml
+++ b/backends/gstreamer/render-android/Cargo.toml
@@ -8,28 +8,11 @@ edition = "2021"
 name = "servo_media_gstreamer_render_android"
 path = "lib.rs"
 
-[dependencies.glib]
-version = "0.17"
-
-[dependencies.gst]
-package = "gstreamer"
-version = "0.20"
-
-[dependencies.gst-gl]
-package = "gstreamer-gl"
-version = "0.20"
-
-[dependencies.gstreamer-gl-egl]
-version = "0.20"
-
-[dependencies.gst-video]
-package = "gstreamer-video"
-version = "0.20"
-
-[dependencies.sm-player]
-package = "servo-media-player"
-path = "../../../player"
-
-[dependencies.sm-gst-render]
-package = "servo-media-gstreamer-render"
-path = "../render"
+[dependencies]
+glib = "0.18"
+gst = { package = "gstreamer", version = "0.21" }
+gst-gl = { package = "gstreamer-gl", version = "0.21" }
+gstreamer-gl-egl = { package = "gstreamer-gl-egl", version = "0.21" }
+gst-video = { package = "gstreamer-video", version = "0.21" }
+sm-player = { package = "servo-media-player", path = "../../../player" }
+sm-gst-render = { package = "servo-media-gstreamer-render", path = "../render" }

--- a/backends/gstreamer/render-android/lib.rs
+++ b/backends/gstreamer/render-android/lib.rs
@@ -5,13 +5,6 @@
 //! wrapping the *appsink* from the Player. And the shared frames are
 //! mapped as texture IDs.
 
-extern crate gstreamer as gst;
-extern crate gstreamer_gl as gst_gl;
-extern crate gstreamer_video as gst_video;
-
-extern crate servo_media_gstreamer_render as sm_gst_render;
-extern crate servo_media_player as sm_player;
-
 use gst::prelude::*;
 use gst_gl::prelude::*;
 use sm_gst_render::Render;
@@ -29,7 +22,7 @@ impl Buffer for GStreamerBuffer {
     fn to_vec(&self) -> Result<VideoFrameData, ()> {
         // packed formats are guaranteed to be in a single plane
         if self.frame.format() == gst_video::VideoFormat::Rgba {
-            let tex_id = self.frame.get_texture_id(0).ok_or_else(|| ())?;
+            let tex_id = self.frame.texture_id(0).ok_or_else(|| ())?;
             Ok(if self.is_external_oes {
                 VideoFrameData::OESTexture(tex_id)
             } else {
@@ -69,14 +62,14 @@ impl RenderAndroid {
             GlApi::OpenGL3 => gst_gl::GLAPI::OPENGL3,
             GlApi::Gles1 => gst_gl::GLAPI::GLES1,
             GlApi::Gles2 => gst_gl::GLAPI::GLES2,
-            GlApi::None => gst_gl::GLAPI::NONE,
+            GlApi::None => return None,
         };
 
         let (wrapped_context, display) = match gl_context {
             GlContext::Egl(context) => {
                 let display = match display_native {
                     NativeDisplay::Egl(display_native) => {
-                        unsafe { gst_gl::GLDisplayEGL::new_with_egl_display(display_native) }
+                        unsafe { gstreamer_gl_egl::GLDisplayEGL::with_egl_display(display_native) }
                             .and_then(|display| Ok(display.upcast()))
                             .ok()
                     }
@@ -122,24 +115,20 @@ impl Render for RenderAndroid {
         if self.gst_context.lock().unwrap().is_none() && self.gl_upload.lock().unwrap().is_some() {
             *self.gst_context.lock().unwrap() =
                 if let Some(glupload) = self.gl_upload.lock().unwrap().as_ref() {
-                    glupload
-                        .get_property("context")
-                        .or_else(|_| Err(()))?
-                        .get::<gst_gl::GLContext>()
-                        .unwrap_or_else(|_| None)
+                    Some(glupload.property::<gst_gl::GLContext>("context"))
                 } else {
                     None
                 };
         }
 
-        let buffer = sample.get_buffer_owned().ok_or_else(|| ())?;
-        let caps = sample.get_caps().ok_or_else(|| ())?;
+        let buffer = sample.buffer_owned().ok_or_else(|| ())?;
+        let caps = sample.caps().ok_or_else(|| ())?;
 
         let is_external_oes = caps
-            .get_structure(0)
+            .structure(0)
             .and_then(|s| {
                 s.get::<&str>("texture-target").ok().and_then(|target| {
-                    if target == Some("external-oes") {
+                    if target == "external-oes" {
                         Some(s)
                     } else {
                         None
@@ -151,7 +140,7 @@ impl Render for RenderAndroid {
         let info = gst_video::VideoInfo::from_caps(caps).map_err(|_| ())?;
 
         if self.gst_context.lock().unwrap().is_some() {
-            if let Some(sync_meta) = buffer.get_meta::<gst_gl::GLSyncMeta>() {
+            if let Some(sync_meta) = buffer.meta::<gst_gl::GLSyncMeta>() {
                 sync_meta.set_sync_point(self.gst_context.lock().unwrap().as_ref().unwrap());
             }
         }
@@ -160,7 +149,7 @@ impl Render for RenderAndroid {
             gst_video::VideoFrame::from_buffer_readable_gl(buffer, &info).or_else(|_| Err(()))?;
 
         if self.gst_context.lock().unwrap().is_some() {
-            if let Some(sync_meta) = frame.buffer().get_meta::<gst_gl::GLSyncMeta>() {
+            if let Some(sync_meta) = frame.buffer().meta::<gst_gl::GLSyncMeta>() {
                 // This should possibly be
                 // sync_meta.wait(&self.app_context);
                 // since we want the main app thread to sync it's GPU pipeline too,
@@ -192,34 +181,32 @@ impl Render for RenderAndroid {
             ));
         }
 
-        let vsinkbin = gst::ElementFactory::make("glsinkbin", Some("servo-media-vsink"))
+        let caps = gst::Caps::builder("video/x-raw")
+            .features([gst_gl::CAPS_FEATURE_MEMORY_GL_MEMORY])
+            .field("format", gst_video::VideoFormat::Rgba.to_str())
+            .field("texture-target", gst::List::new(["2D", "external-oes"]))
+            .build();
+        appsink.set_property("caps", &caps);
+
+        let vsinkbin = gst::ElementFactory::make("glsinkbin")
+            .name("servo-media-vsink")
+            .property("sink", &appsink)
+            .build()
             .map_err(|_| PlayerError::Backend("glupload creation failed".to_owned()))?;
 
-        let caps = gst::Caps::builder("video/x-raw")
-            .features(&[&gst_gl::CAPS_FEATURE_MEMORY_GL_MEMORY])
-            .field("format", &gst_video::VideoFormat::Rgba.to_string())
-            .field("texture-target", &gst::List::new(&[&"2D", &"external-oes"]))
-            .build();
-        appsink
-            .set_property("caps", &caps)
-            .expect("appsink doesn't have expected 'caps' property");
+        pipeline.set_property("video-sink", &vsinkbin);
 
-        vsinkbin
-            .set_property("sink", &appsink)
-            .expect("glsinkbin doesn't have expected 'sink' property");
-
-        pipeline
-            .set_property("video-sink", &vsinkbin)
-            .expect("playbin doesn't have expected 'video-sink' property");
-
-        let bus = pipeline.get_bus().expect("pipeline with no bus");
+        let bus = pipeline.bus().expect("pipeline with no bus");
         let display_ = self.display.clone();
         let context_ = self.app_context.clone();
         bus.set_sync_handler(move |_, msg| {
             match msg.view() {
                 gst::MessageView::NeedContext(ctxt) => {
-                    if let Some(el) = msg.get_src().map(|s| s.downcast::<gst::Element>().unwrap()) {
-                        let context_type = ctxt.get_context_type();
+                    if let Some(el) = msg
+                        .src()
+                        .map(|s| s.clone().downcast::<gst::Element>().unwrap())
+                    {
+                        let context_type = ctxt.context_type();
                         if context_type == *gst_gl::GL_DISPLAY_CONTEXT_TYPE {
                             let ctxt = gst::Context::new(context_type, true);
                             ctxt.set_gl_display(&display_);
@@ -227,7 +214,7 @@ impl Render for RenderAndroid {
                         } else if context_type == "gst.gl.app_context" {
                             let mut ctxt = gst::Context::new(context_type, true);
                             {
-                                let s = ctxt.get_mut().unwrap().get_mut_structure();
+                                let s = ctxt.get_mut().unwrap().structure_mut();
                                 s.set_value("context", context_.to_send_value());
                             }
                             el.set_context(&ctxt);
@@ -247,7 +234,7 @@ impl Render for RenderAndroid {
         *self.gl_upload.lock().unwrap() = loop {
             match iter.next() {
                 Ok(Some(element)) => {
-                    if "glupload" == element.get_factory().unwrap().get_name() {
+                    if Some(true) == element.factory().map(|f| f.name() == "glupload") {
                         break Some(element);
                     }
                 }

--- a/backends/gstreamer/render-unix/Cargo.toml
+++ b/backends/gstreamer/render-unix/Cargo.toml
@@ -2,30 +2,48 @@
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
+edition = "2021"
 
 [features]
-gl-egl = ["gstreamer-gl/egl"]
-gl-x11 = ["gstreamer-gl/x11"]
-gl-wayland = ["gstreamer-gl/wayland"]
+gl-egl = ["gstreamer-gl-egl"]
+gl-x11 = ["gstreamer-gl-x11"]
+gl-wayland = ["gstreamer-gl-wayland"]
 
 [lib]
 name = "servo_media_gstreamer_render_unix"
 path = "lib.rs"
 
 [dependencies.glib]
-version = "0.9"
+version = "0.17"
 
-[dependencies.gstreamer]
-version = "0.15"
+[dependencies.gst]
+package = "gstreamer"
+version = "0.20"
 
-[dependencies.gstreamer-gl]
-version = "0.15"
+[dependencies.gst-gl]
+package = "gstreamer-gl"
+version = "0.20"
 
-[dependencies.gstreamer-video]
-version = "0.15"
+[dependencies.gstreamer-gl-egl]
+version = "0.20"
+optional = true
 
-[dependencies.servo-media-player]
+[dependencies.gstreamer-gl-x11]
+version = "0.20"
+optional = true
+
+[dependencies.gstreamer-gl-wayland]
+version = "0.20"
+optional = true
+
+[dependencies.gst-video]
+package = "gstreamer-video"
+version = "0.20"
+
+[dependencies.sm-player]
+package = "servo-media-player"
 path = "../../../player"
 
-[dependencies.servo-media-gstreamer-render]
+[dependencies.sm-gst-render]
+package = "servo-media-gstreamer-render"
 path = "../render"

--- a/backends/gstreamer/render-unix/Cargo.toml
+++ b/backends/gstreamer/render-unix/Cargo.toml
@@ -13,37 +13,13 @@ gl-wayland = ["gstreamer-gl-wayland"]
 name = "servo_media_gstreamer_render_unix"
 path = "lib.rs"
 
-[dependencies.glib]
-version = "0.17"
-
-[dependencies.gst]
-package = "gstreamer"
-version = "0.20"
-
-[dependencies.gst-gl]
-package = "gstreamer-gl"
-version = "0.20"
-
-[dependencies.gstreamer-gl-egl]
-version = "0.20"
-optional = true
-
-[dependencies.gstreamer-gl-x11]
-version = "0.20"
-optional = true
-
-[dependencies.gstreamer-gl-wayland]
-version = "0.20"
-optional = true
-
-[dependencies.gst-video]
-package = "gstreamer-video"
-version = "0.20"
-
-[dependencies.sm-player]
-package = "servo-media-player"
-path = "../../../player"
-
-[dependencies.sm-gst-render]
-package = "servo-media-gstreamer-render"
-path = "../render"
+[dependencies]
+glib = "0.18"
+gst = { package = "gstreamer", version = "0.21" }
+gst-gl = { package = "gstreamer-gl", version = "0.21" }
+gstreamer-gl-egl = { version = "0.21", optional = true }
+gstreamer-gl-x11 = { version = "0.21", optional = true }
+gstreamer-gl-wayland = { version = "0.21", optional = true }
+gst-video = { package = "gstreamer-video", version = "0.21" }
+sm-player = { package = "servo-media-player", path = "../../../player" }
+sm-gst-render = { package = "servo-media-gstreamer-render", path = "../render" }

--- a/backends/gstreamer/render.rs
+++ b/backends/gstreamer/render.rs
@@ -135,7 +135,7 @@ impl GStreamerRender {
             .unwrap();
 
         if let Some(render) = self.render.as_ref() {
-            render.build_video_sink(appsink.upcast_ref(), pipeline)?
+            render.build_video_sink(appsink.upcast_ref::<gst::Element>(), pipeline)?
         } else {
             let caps = gst::Caps::builder("video/x-raw")
                 .field("format", gst_video::VideoFormat::Bgra.to_str())

--- a/backends/gstreamer/render/Cargo.toml
+++ b/backends/gstreamer/render/Cargo.toml
@@ -7,11 +7,14 @@ authors = ["The Servo Project Developers"]
 name = "servo_media_gstreamer_render"
 path = "lib.rs"
 
-[dependencies.gstreamer]
-version = "0.15"
+[dependencies.gst]
+package = "gstreamer"
+version = "0.20"
 
-[dependencies.gstreamer-video]
-version = "0.15"
+[dependencies.gst-video]
+package = "gstreamer-video"
+version = "0.20"
 
-[dependencies.servo-media-player]
+[dependencies.sm-player]
+package = "servo-media-player"
 path = "../../../player"

--- a/backends/gstreamer/render/Cargo.toml
+++ b/backends/gstreamer/render/Cargo.toml
@@ -7,13 +7,9 @@ authors = ["The Servo Project Developers"]
 name = "servo_media_gstreamer_render"
 path = "lib.rs"
 
-[dependencies.gst]
-package = "gstreamer"
-version = "0.20"
-
-[dependencies.gst-video]
-package = "gstreamer-video"
-version = "0.20"
+[dependencies]
+gst = { package = "gstreamer", version = "0.21" }
+gst-video = { package = "gstreamer-video", version = "0.21" }
 
 [dependencies.sm-player]
 package = "servo-media-player"

--- a/backends/gstreamer/render/lib.rs
+++ b/backends/gstreamer/render/lib.rs
@@ -12,9 +12,6 @@
 //! of this trait, so the player could setup a proper GStreamer
 //! pipeline, and handle the produced buffers.
 //!
-extern crate gstreamer as gst;
-
-extern crate servo_media_player as sm_player;
 
 pub trait Render {
     /// Returns `True` if the render implementation uses any version

--- a/backends/gstreamer/render/lib.rs
+++ b/backends/gstreamer/render/lib.rs
@@ -20,8 +20,8 @@ pub trait Render {
 
     /// Returns the Player's `Frame` to be consumed by the API user.
     ///
-    /// The implementator of this method will map the `sample`'s
-    /// buffer to the rendering appropiate structure. In the case of
+    /// The implementation of this method will map the `sample`'s
+    /// buffer to the rendering appropriate structure. In the case of
     /// OpenGL-based renders, the `Frame`, instead of the raw data,
     /// will transfer the texture ID.
     ///

--- a/backends/gstreamer/source.rs
+++ b/backends/gstreamer/source.rs
@@ -242,7 +242,7 @@ mod imp {
                 .expect("Could not create appsrc element");
 
             let pad_templ = klass.pad_template("src").unwrap();
-            let ghost_pad = gst::GhostPad::builder_with_template(&pad_templ, Some("src"))
+            let ghost_pad = gst::GhostPad::builder_from_template(&pad_templ).name("src")
                 .query_function(|pad, parent, query| {
                     ServoSrc::catch_panic_pad_function(
                         parent,

--- a/backends/gstreamer/webrtc.rs
+++ b/backends/gstreamer/webrtc.rs
@@ -644,7 +644,7 @@ pub fn construct(
     thread: WebRtcThread,
 ) -> Result<GStreamerWebRtcController, WebRtcError> {
     let main_loop = glib::MainLoop::new(None, false);
-    let pipeline = gst::Pipeline::new(Some("webrtc main"));
+    let pipeline = gst::Pipeline::with_name("webrtc main");
     pipeline.set_start_time(gst::ClockTime::NONE);
     pipeline.set_base_time(*BACKEND_BASE_TIME);
     pipeline.use_clock(Some(&gst::SystemClock::obtain()));

--- a/examples/android/lib/src/lib.rs
+++ b/examples/android/lib/src/lib.rs
@@ -114,6 +114,7 @@ pub mod android {
 
 #[test]
 fn it_works() {
+    use std::ffi::CString;
     let backend_id = unsafe { CString::from_raw(servo_media_backend_id()) };
     assert_eq!(backend_id.to_str().unwrap(), "GStreamer");
 }

--- a/examples/player/context.rs
+++ b/examples/player/context.rs
@@ -25,8 +25,6 @@ impl PlayerContextGlutin {
         }
 
         let (gl_context, native_display, gl_api) = {
-            use glutin::os::ContextTraitExt;
-
             let context = windowed_context.context();
             let raw_handle = unsafe { context.raw_handle() };
             let api = windowed_context.get_api();

--- a/webrtc/datachannel.rs
+++ b/webrtc/datachannel.rs
@@ -12,7 +12,6 @@ pub enum DataChannelMessage {
 
 #[derive(Debug)]
 pub enum DataChannelState {
-    New,
     Connecting,
     Open,
     Closing,


### PR DESCRIPTION
I've upgraded the version of the GStreamer Rust bindings. I've tried to make the minimal possible changes to the code, keeping all previous logic and behavior.

Please let me know if I've missed anything.