### PR TITLE
Update ipc-channel to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,19 +385,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.14",
@@ -1345,12 +1335,12 @@ dependencies = [
 
 [[package]]
 name = "ipc-channel"
-version = "0.14.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3698b8affd5656032a074a7d40b3c2a29b71971f3e1ff6042b9d40724e20d97c"
+checksum = "342d636452fbc2895574e0b319b23c014fd01c9ed71dcd87f6a4a8e2f948db4b"
 dependencies = [
  "bincode",
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "fnv",
  "lazy_static",
  "libc",
@@ -1358,7 +1348,8 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "tempfile",
- "uuid",
+ "uuid 1.3.4",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2147,7 +2138,7 @@ version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
- "crossbeam-channel 0.5.6",
+ "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils 0.8.14",
  "num_cpus",
@@ -2511,7 +2502,7 @@ name = "servo-media-streams"
 version = "0.1.0"
 dependencies = [
  "lazy_static",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2526,7 +2517,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.17",
  "servo-media-streams",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2928,6 +2919,15 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.8",
+]
+
+[[package]]
+name = "uuid"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 dependencies = [
  "getrandom 0.2.8",
 ]

--- a/backends/dummy/Cargo.toml
+++ b/backends/dummy/Cargo.toml
@@ -9,7 +9,7 @@ path = "lib.rs"
 
 [dependencies]
 boxfnonce = "0.1.0"
-ipc-channel = "0.14"
+ipc-channel = "0.16"
 servo-media = { path = "../../servo-media" }
 servo-media-audio = { path = "../../audio" }
 servo-media-player = { path = "../../player" }

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -56,7 +56,7 @@ features = ["v1_16"]
 version = "0.15"
 
 [dependencies.ipc-channel]
-version = "0.14"
+version = "0.16"
 
 [dependencies.lazy_static]
 version = "1.2.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,7 +20,7 @@ servo-media = { path = "../servo-media" }
 webrender = { version = "0.60.0", optional = true }
 webrender_api = { version = "0.60.0", optional = true }
 websocket = { version = "0.22", optional = true }
-ipc-channel = { version = "0.14", optional = true }
+ipc-channel = { version = "0.16", optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 winit = { version = "0.19", optional = true }

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 [dependencies]
 serde = "1.0.66"
 serde_derive = "1.0.66"
-ipc-channel = "0.14"
+ipc-channel = "0.16"
 
 [dependencies.servo-media-streams]
 path = "../streams"


### PR DESCRIPTION
ipc-channel used in servo needs to bumped to 0.16.1 to complete https://github.com/servo/servo/issues/29467, but that requires the same version to be used by media crates as well.

FYI: I had accidentally pushed my change to master branch of this repo. I've now force pushed master to it's previous state. I've also made 'master' a protected branch. Please let me know if that needs to be changed or removed.