### PR TITLE
Initialize media in the background

### DIFF
--- a/servo-media/Cargo.toml
+++ b/servo-media/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 name = "servo_media"
 path = "lib.rs"
 
+[dependencies]
+once_cell = "1.18.0"
+
 [dependencies.servo-media-audio]
 path = "../audio"
 


### PR DESCRIPTION
Move initialization of the media engine to a background thread. This
also replaced the complex INITIALIZER / INSTANCE combo with a single
synchronous `OnceCell`. Finally, instead of taking in the `Backend` as
an argument, take in a factory function. This allows the `Backend` to
also be initialized off the main thread.

This allows GStreamer plugin cache initialization to happen off the main
thread and removes unsafe code in initialization.

Co-authored-by: Rakhi Sharma <atbrakhi@igalia.com>
