### PR TITLE
Run a glib main loop for the GStreamer backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
@@ -2339,6 +2339,7 @@ dependencies = [
 name = "servo-media"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
  "servo-media-audio",
  "servo-media-player",
  "servo-media-streams",
@@ -2410,6 +2411,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.17",
  "mime 0.3.17",
+ "once_cell",
  "servo-media",
  "servo-media-audio",
  "servo-media-gstreamer-render",

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -25,6 +25,7 @@ ipc-channel = { workspace = true }
 lazy_static = "1.2.0"
 log = "0.4"
 mime = "0.3.13"
+once_cell = "1.18.0"
 servo-media = { path = "../../servo-media" }
 servo-media-audio = { path = "../../audio" }
 servo-media-gstreamer-render = { path = "render" }


### PR DESCRIPTION
This is a workaround for an issue where GStreamer does not deliver end
of stream signals unless there is a main loop running. See [1] for
more information.

1. https://github.com/servo/media/pull/393#issuecomment-1813934250

Co-authored-by: Víctor Manuel Jáquez Leal <vjaquez@igalia.com>
