### PR TITLE
Add licenses to all Cargo.toml files

### DIFF
--- a/backends/auto/Cargo.toml
+++ b/backends/auto/Cargo.toml
@@ -3,6 +3,7 @@ name = "servo-media-auto"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
 edition = "2021"
+license = "MPL-2.0"
 
 [lib]
 name = "servo_media_auto"

--- a/backends/dummy/Cargo.toml
+++ b/backends/dummy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "servo-media-dummy"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "servo_media_dummy"

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -3,6 +3,7 @@ name = "servo-media-gstreamer"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
 edition = "2021"
+license = "MPL-2.0"
 
 [lib]
 name = "servo_media_gstreamer"

--- a/backends/gstreamer/render-android/Cargo.toml
+++ b/backends/gstreamer/render-android/Cargo.toml
@@ -3,6 +3,7 @@ name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
 edition = "2021"
+license = "MPL-2.0"
 
 [lib]
 name = "servo_media_gstreamer_render_android"

--- a/backends/gstreamer/render-unix/Cargo.toml
+++ b/backends/gstreamer/render-unix/Cargo.toml
@@ -3,6 +3,7 @@ name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
 edition = "2021"
+license = "MPL-2.0"
 
 [features]
 gl-egl = ["gstreamer-gl-egl"]

--- a/backends/gstreamer/render/Cargo.toml
+++ b/backends/gstreamer/render/Cargo.toml
@@ -2,6 +2,7 @@
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "servo_media_gstreamer_render"

--- a/examples/android/lib/Cargo.toml
+++ b/examples/android/lib/Cargo.toml
@@ -3,6 +3,7 @@ name = "servo_media_android"
 description = "Android lib to use Servo Media from Android Java"
 version = "0.1.0"
 authors = ["Fernando Jiménez Moreno <ferjmoreno@gmail.com>"]
+license = "MPL-2.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/servo-media-derive/Cargo.toml
+++ b/servo-media-derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "servo_media_derive"
 version = "0.1.0"
 authors = ["Fernando Jiménez Moreno <ferjmoreno@gmail.com>"]
+license = "MPL-2.0"
 
 [lib]
 name = "servo_media_derive"

--- a/servo-media/Cargo.toml
+++ b/servo-media/Cargo.toml
@@ -2,6 +2,7 @@
 name = "servo-media"
 version = "0.1.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
+license = "MPL-2.0"
 
 [lib]
 name = "servo_media"

--- a/streams/Cargo.toml
+++ b/streams/Cargo.toml
@@ -3,6 +3,7 @@ name = "servo-media-streams"
 version = "0.1.0"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
+license = "MPL-2.0"
 
 [lib]
 name = "servo_media_streams"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -2,6 +2,7 @@
 name = "servo-media-traits"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "servo_media_traits"

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "servo-media-webrtc"
 version = "0.1.0"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
+license = "MPL-2.0"
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
This will allow `cargo license` to work properly in the future.
