### PR TITLE
Rename `servo_media_derive` to `servo-media-derive`

### DIFF
--- a/audio/Cargo.toml
+++ b/audio/Cargo.toml
@@ -14,7 +14,7 @@ euclid = "0.22"
 log = "0.4"
 serde_derive = "1.0.66"
 serde = "1.0.66"
-servo_media_derive = { path = "../servo-media-derive" }
+servo-media-derive = { path = "../servo-media-derive" }
 servo-media-player = { path = "../player" }
 servo-media-traits = { path = "../traits" }
 servo-media-streams = { path = "../streams" }

--- a/servo-media-derive/Cargo.toml
+++ b/servo-media-derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "servo_media_derive"
+name = "servo-media-derive"
 version = "0.1.0"
 authors = ["Fernando Jiménez Moreno <ferjmoreno@gmail.com>"]
 


### PR DESCRIPTION
This is the only servo media package that uses underscores in the name
when all the others use dashes.
