### PR TITLE
Stop using the `boxfnonce` library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,12 +152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
-name = "boxfnonce"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
-
-[[package]]
 name = "build-parallel"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,7 +2504,6 @@ dependencies = [
 name = "servo-media-audio"
 version = "0.2.0"
 dependencies = [
- "boxfnonce",
  "byte-slice-cast",
  "euclid",
  "log 0.4.17",
@@ -2519,10 +2512,10 @@ dependencies = [
  "petgraph",
  "serde",
  "serde_derive",
+ "servo-media-derive",
  "servo-media-player",
  "servo-media-streams",
  "servo-media-traits",
- "servo_media_derive",
  "smallvec 1.10.0",
  "speexdsp-resampler",
 ]
@@ -2536,10 +2529,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo-media-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
 dependencies = [
- "boxfnonce",
  "ipc-channel",
  "servo-media",
  "servo-media-audio",
@@ -2553,7 +2554,6 @@ dependencies = [
 name = "servo-media-gstreamer"
 version = "0.1.0"
 dependencies = [
- "boxfnonce",
  "byte-slice-cast",
  "glib",
  "glib-sys",
@@ -2647,7 +2647,6 @@ version = "0.1.0"
 name = "servo-media-webrtc"
 version = "0.1.0"
 dependencies = [
- "boxfnonce",
  "lazy_static",
  "log 0.4.17",
  "servo-media-streams",
@@ -2661,15 +2660,6 @@ dependencies = [
  "jni",
  "servo-media",
  "servo-media-auto",
-]
-
-[[package]]
-name = "servo_media_derive"
-version = "0.1.0"
-dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 1.0.107",
 ]
 
 [[package]]

--- a/audio/Cargo.toml
+++ b/audio/Cargo.toml
@@ -9,7 +9,6 @@ name = "servo_media_audio"
 path = "lib.rs"
 
 [dependencies]
-boxfnonce = "0.1"
 euclid = "0.22"
 log = "0.4"
 serde_derive = "1.0.66"

--- a/audio/lib.rs
+++ b/audio/lib.rs
@@ -6,7 +6,6 @@ extern crate servo_media_derive;
 
 extern crate servo_media_player as player;
 
-extern crate boxfnonce;
 extern crate byte_slice_cast;
 extern crate euclid;
 extern crate log;

--- a/audio/node.rs
+++ b/audio/node.rs
@@ -1,6 +1,5 @@
 use biquad_filter_node::{BiquadFilterNodeMessage, BiquadFilterNodeOptions};
 use block::{Block, Chunk, Tick};
-use boxfnonce::SendBoxFnOnce;
 use buffer_source_node::{AudioBufferSourceNodeMessage, AudioBufferSourceNodeOptions};
 use channel_node::ChannelNodeOptions;
 use constant_source_node::ConstantSourceNodeOptions;
@@ -204,11 +203,11 @@ pub enum AudioNodeMessage {
     WaveShaperNode(WaveShaperNodeMessage),
 }
 
-pub struct OnEndedCallback(pub SendBoxFnOnce<'static, ()>);
+pub struct OnEndedCallback(pub Box<dyn FnOnce() + Send + 'static>);
 
 impl OnEndedCallback {
     pub fn new<F: FnOnce() + Send + 'static>(callback: F) -> Self {
-        OnEndedCallback(SendBoxFnOnce::new(callback))
+        OnEndedCallback(Box::new(callback))
     }
 }
 

--- a/backends/dummy/Cargo.toml
+++ b/backends/dummy/Cargo.toml
@@ -9,7 +9,6 @@ name = "servo_media_dummy"
 path = "lib.rs"
 
 [dependencies]
-boxfnonce = "0.1.0"
 ipc-channel = { workspace = true }
 servo-media = { path = "../../servo-media" }
 servo-media-audio = { path = "../../audio" }

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -1,4 +1,3 @@
-extern crate boxfnonce;
 extern crate ipc_channel;
 extern crate servo_media;
 extern crate servo_media_audio;
@@ -7,7 +6,6 @@ extern crate servo_media_streams;
 extern crate servo_media_traits;
 extern crate servo_media_webrtc;
 
-use boxfnonce::SendBoxFnOnce;
 use ipc_channel::ipc::IpcSender;
 use servo_media::{Backend, BackendInit, SupportsMediaType};
 use servo_media_audio::block::{Block, Chunk};
@@ -288,24 +286,24 @@ impl WebRtcControllerBackend for DummyWebRtcController {
     fn set_remote_description(
         &mut self,
         _: SessionDescription,
-        _: SendBoxFnOnce<'static, ()>,
+        _: Box<dyn FnOnce() + Send + 'static>,
     ) -> WebRtcResult {
         Ok(())
     }
     fn set_local_description(
         &mut self,
         _: SessionDescription,
-        _: SendBoxFnOnce<'static, ()>,
+        _: Box<dyn FnOnce() + Send + 'static>,
     ) -> WebRtcResult {
         Ok(())
     }
     fn add_ice_candidate(&mut self, _: IceCandidate) -> WebRtcResult {
         Ok(())
     }
-    fn create_offer(&mut self, _: SendBoxFnOnce<'static, (SessionDescription,)>) -> WebRtcResult {
+    fn create_offer(&mut self, _: Box<dyn FnOnce(SessionDescription) + Send + 'static>) -> WebRtcResult {
         Ok(())
     }
-    fn create_answer(&mut self, _: SendBoxFnOnce<'static, (SessionDescription,)>) -> WebRtcResult {
+    fn create_answer(&mut self, _: Box<dyn FnOnce(SessionDescription) + Send + 'static>) -> WebRtcResult {
         Ok(())
     }
     fn add_stream(&mut self, _: &MediaStreamId) -> WebRtcResult {

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -10,7 +10,6 @@ name = "servo_media_gstreamer"
 path = "lib.rs"
 
 [dependencies]
-boxfnonce = "0.1.0"
 byte-slice-cast = "0.2"
 glib = "0.18"
 glib-sys = "0.18"

--- a/servo-media-derive/lib.rs
+++ b/servo-media-derive/lib.rs
@@ -92,7 +92,7 @@ fn impl_audio_scheduled_source_node(ast: &syn::DeriveInput) -> proc_macro2::Toke
                     return;
                 }
                 if let Some(cb) = self.onended_callback.take() {
-                    cb.0.call()
+                    cb.0()
                 }
             }
 

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -8,7 +8,6 @@ license = "MPL-2.0"
 path = "lib.rs"
 
 [dependencies]
-boxfnonce = "0.1.0"
 lazy_static = "1.0"
 log = "0.4.6"
 uuid = { version = "1.4", features = ["v4"] }

--- a/webrtc/lib.rs
+++ b/webrtc/lib.rs
@@ -1,4 +1,3 @@
-extern crate boxfnonce;
 extern crate log;
 extern crate servo_media_streams;
 extern crate uuid;
@@ -8,8 +7,6 @@ use servo_media_streams::MediaStreamType;
 
 use std::fmt::Display;
 use std::str::FromStr;
-
-use boxfnonce::SendBoxFnOnce;
 
 pub mod datachannel;
 pub mod thread;
@@ -40,16 +37,16 @@ pub trait WebRtcControllerBackend: Send {
     fn set_remote_description(
         &mut self,
         _: SessionDescription,
-        cb: SendBoxFnOnce<'static, ()>,
+        cb: Box<dyn FnOnce() + Send + 'static>,
     ) -> WebRtcResult;
     fn set_local_description(
         &mut self,
         _: SessionDescription,
-        cb: SendBoxFnOnce<'static, ()>,
+        cb: Box<dyn FnOnce() + Send + 'static>,
     ) -> WebRtcResult;
     fn add_ice_candidate(&mut self, candidate: IceCandidate) -> WebRtcResult;
-    fn create_offer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>) -> WebRtcResult;
-    fn create_answer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>) -> WebRtcResult;
+    fn create_offer(&mut self, cb: Box<dyn FnOnce(SessionDescription,) + Send + 'static>) -> WebRtcResult;
+    fn create_answer(&mut self, cb: Box<dyn FnOnce(SessionDescription,) + Send + 'static>) -> WebRtcResult;
     fn add_stream(&mut self, stream: &MediaStreamId) -> WebRtcResult;
 
     fn create_data_channel(&mut self, init: &DataChannelInit) -> WebRtcDataChannelResult;


### PR DESCRIPTION
This is no longer necessary in modern versions of Rust and the library
is now unmaintained. See
https://blog.rust-lang.org/2019/05/23/Rust-1.35.0.html#fn-closure-traits-implemented-for-box%3Cdyn-fn*%3E
