### PR TITLE
Render first video frame when preroll is available

### DIFF
--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -619,6 +619,8 @@ impl GStreamerPlayer {
         });
 
         if let Some(video_renderer) = self.video_renderer.clone() {
+            // Creates a closure that renders a frame using the video_renderer
+            // Used in the preroll and sample callbacks
             let render_sample = {
                 let render = self.render.clone();
                 let observer = self.observer.clone();


### PR DESCRIPTION
In order to display the first frame of a video that doesn't autoplay we can use [preroll](https://gstreamer.freedesktop.org/documentation/additional/design/preroll.html?gi-language=c). This guarantees that when the video is in the state PAUSED it has at least one buffer ready, which we can send to the video renderer.

The closure from the `new_sample` callback has been extracted since the logic for rendering video samples and preroll samples is the same.

Fixes servo/servo#31666. A detailed log of the reasoning behind this change and an alternative implementation (which required a new api function so this one was favoured) can be found on that issue.