### PR TITLE
Handle errors from AudioRenderThread::start

### DIFF
--- a/audio/context.rs
+++ b/audio/context.rs
@@ -156,14 +156,13 @@ impl AudioContext {
             })
             .expect("Failed to spawn AudioRenderThread");
 
-        let thread_result = result_receiver.try_recv();
+        let thread_result = result_receiver
+            .recv()
+            .expect("Failed to receive result from AudioRenderThread");
 
-        let inner_result = match thread_result {
-            Ok(inner) => inner,
-            Err(_) => return Err(AudioSinkError::StateChangeFailed),
-        };
-
-        inner_result.map_err(|e| e.into())?;
+        if let Err(e) = thread_result {
+            return Err(e);
+        }
 
         Ok(Self {
             id,

--- a/audio/context.rs
+++ b/audio/context.rs
@@ -152,7 +152,7 @@ impl AudioContext {
             .spawn(move || {
                 let result =
                     AudioRenderThread::start::<B>(receiver, sender_, sample_rate, graph, options);
-                result_sender.send(result).unwrap();
+                let _ = result_sender.send(result);
             })
             .expect("Failed to spawn AudioRenderThread");
 

--- a/audio/context.rs
+++ b/audio/context.rs
@@ -156,11 +156,14 @@ impl AudioContext {
             })
             .expect("Failed to spawn AudioRenderThread");
 
-        let thread_result: Result<(), AudioSinkError> = result_receiver.recv().unwrap();
+        let thread_result = result_receiver.try_recv();
 
-        if let Err(e) = thread_result {
-            return Err(e);
-        }
+        let inner_result = match thread_result {
+            Ok(inner) => inner,
+            Err(_) => return Err(AudioSinkError::StateChangeFailed),
+        };
+
+        inner_result.map_err(|e| e.into())?;
 
         Ok(Self {
             id,

--- a/audio/render_thread.rs
+++ b/audio/render_thread.rs
@@ -160,10 +160,10 @@ impl AudioRenderThread {
         sample_rate: f32,
         graph: AudioGraph,
         options: AudioContextOptions,
-    ) {
-        let mut thread = Self::prepare_thread::<B>(sender.clone(), sample_rate, graph, options)
-            .expect("Could not start audio render thread");
-        thread.event_loop(event_queue)
+    ) -> Result<(), AudioSinkError> {
+        let mut thread = Self::prepare_thread::<B>(sender.clone(), sample_rate, graph, options)?;
+        thread.event_loop(event_queue);
+        Ok(())
     }
 
     make_render_thread_state_change!(resume, Running, play);

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -94,12 +94,12 @@ impl Backend for DummyBackend {
         &self,
         _id: &ClientContextId,
         options: AudioContextOptions,
-    ) -> Arc<Mutex<AudioContext>> {
+    ) -> Result<Arc<Mutex<AudioContext>>, AudioSinkError> {
         let (sender, _) = mpsc::channel();
         let sender = Arc::new(Mutex::new(sender));
-        Arc::new(Mutex::new(
+        Ok(Arc::new(Mutex::new(
             AudioContext::new::<Self>(0, &ClientContextId::build(1, 1), sender, options).unwrap(),
-        ))
+        )))
     }
 
     fn create_webrtc(&self, signaller: Box<dyn WebRtcSignaller>) -> WebRtcController {

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -97,12 +97,9 @@ impl Backend for DummyBackend {
     ) -> Arc<Mutex<AudioContext>> {
         let (sender, _) = mpsc::channel();
         let sender = Arc::new(Mutex::new(sender));
-        Arc::new(Mutex::new(AudioContext::new::<Self>(
-            0,
-            &ClientContextId::build(1, 1),
-            sender,
-            options,
-        )))
+        Arc::new(Mutex::new(
+            AudioContext::new::<Self>(0, &ClientContextId::build(1, 1), sender, options).unwrap(),
+        ))
     }
 
     fn create_webrtc(&self, signaller: Box<dyn WebRtcSignaller>) -> WebRtcController {
@@ -300,10 +297,16 @@ impl WebRtcControllerBackend for DummyWebRtcController {
     fn add_ice_candidate(&mut self, _: IceCandidate) -> WebRtcResult {
         Ok(())
     }
-    fn create_offer(&mut self, _: Box<dyn FnOnce(SessionDescription) + Send + 'static>) -> WebRtcResult {
+    fn create_offer(
+        &mut self,
+        _: Box<dyn FnOnce(SessionDescription) + Send + 'static>,
+    ) -> WebRtcResult {
         Ok(())
     }
-    fn create_answer(&mut self, _: Box<dyn FnOnce(SessionDescription) + Send + 'static>) -> WebRtcResult {
+    fn create_answer(
+        &mut self,
+        _: Box<dyn FnOnce(SessionDescription) + Send + 'static>,
+    ) -> WebRtcResult {
         Ok(())
     }
     fn add_stream(&mut self, _: &MediaStreamId) -> WebRtcResult {

--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -97,9 +97,12 @@ impl Backend for DummyBackend {
     ) -> Result<Arc<Mutex<AudioContext>>, AudioSinkError> {
         let (sender, _) = mpsc::channel();
         let sender = Arc::new(Mutex::new(sender));
-        Ok(Arc::new(Mutex::new(
-            AudioContext::new::<Self>(0, &ClientContextId::build(1, 1), sender, options).unwrap(),
-        )))
+        Ok(Arc::new(Mutex::new(AudioContext::new::<Self>(
+            0,
+            &ClientContextId::build(1, 1),
+            sender,
+            options,
+        )?)))
     }
 
     fn create_webrtc(&self, signaller: Box<dyn WebRtcSignaller>) -> WebRtcController {

--- a/backends/gstreamer/lib.rs
+++ b/backends/gstreamer/lib.rs
@@ -186,23 +186,16 @@ impl Backend for GStreamerBackend {
         options: AudioContextOptions,
     ) -> Result<Arc<Mutex<AudioContext>>, AudioSinkError> {
         let id = self.next_instance_id.fetch_add(1, Ordering::Relaxed);
-        let context_result =
-            AudioContext::new::<Self>(id, client_context_id, self.backend_chan.clone(), options);
+        let audio_context =
+            AudioContext::new::<Self>(id, client_context_id, self.backend_chan.clone(), options)?;
 
-        match context_result {
-            Ok(context) => {
-                let context_arc = Arc::new(Mutex::new(context));
+        let audio_context = Arc::new(Mutex::new(audio_context));
 
-                {
-                    let mut instances = self.instances.lock().unwrap();
-                    let entry = instances.entry(*client_context_id).or_insert(Vec::new());
-                    entry.push((id, Arc::downgrade(&context_arc).clone()));
-                }
+        let mut instances = self.instances.lock().unwrap();
+        let entry = instances.entry(*client_context_id).or_insert(Vec::new());
+        entry.push((id, Arc::downgrade(&audio_context).clone()));
 
-                Ok(context_arc)
-            }
-            Err(e) => Err(e),
-        }
+        Ok(audio_context)
     }
 
     fn create_webrtc(&self, signaller: Box<dyn WebRtcSignaller>) -> WebRtcController {

--- a/examples/muted_audiocontext.rs
+++ b/examples/muted_audiocontext.rs
@@ -13,7 +13,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     let context_id1 = &ClientContextId::build(1, 1);
     let context1 = servo_media.create_audio_context(&context_id1, Default::default());
     {
-        let context = context1.lock().unwrap();
+        let context = context1.unwrap().lock().unwrap();
         let dest = context.dest_node();
         let options = OscillatorNodeOptions::default();
         let osc1 = context.create_node(
@@ -33,7 +33,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     {
         let mut options = OscillatorNodeOptions::default();
         options.oscillator_type = Sawtooth;
-        let context = context2.lock().unwrap();
+        let context = context2.unwrap().lock().unwrap();
         let dest = context.dest_node();
         let osc3 = context.create_node(
             AudioNodeInit::OscillatorNode(options.clone()),

--- a/examples/params_connect2.rs
+++ b/examples/params_connect2.rs
@@ -12,7 +12,7 @@ use std::{thread, time};
 fn run_example(servo_media: Arc<ServoMedia>) {
     let context =
         servo_media.create_audio_context(&ClientContextId::build(1, 1), Default::default());
-    let context = context.lock().unwrap();
+    let context = context.unwrap().lock().unwrap();
     let mut options = OscillatorNodeOptions::default();
     options.freq = 2.0;
     let lfo = context.create_node(AudioNodeInit::OscillatorNode(options), Default::default());

--- a/examples/stream_reader_node.rs
+++ b/examples/stream_reader_node.rs
@@ -10,7 +10,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
     let context =
         servo_media.create_audio_context(&ClientContextId::build(1, 1), Default::default());
     let input = servo_media.create_audiostream();
-    let context = context.lock().unwrap();
+    let context = context.unwrap().lock().unwrap();
     let dest = context.dest_node();
     let osc1 = context.create_node(
         AudioNodeInit::MediaStreamSourceNode(input),

--- a/servo-media/lib.rs
+++ b/servo-media/lib.rs
@@ -6,14 +6,16 @@ pub extern crate servo_media_webrtc as webrtc;
 
 extern crate once_cell;
 
-use audio::sink::AudioSinkError;
 pub use traits::*;
 
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use audio::context::{AudioContext, AudioContextOptions};
+use audio::{
+    context::{AudioContext, AudioContextOptions},
+    sink::AudioSinkError,
+};
 use player::audio::AudioRenderer;
 use player::context::PlayerGLContext;
 use player::ipc_channel::ipc::IpcSender;

--- a/servo-media/lib.rs
+++ b/servo-media/lib.rs
@@ -6,6 +6,7 @@ pub extern crate servo_media_webrtc as webrtc;
 
 extern crate once_cell;
 
+use audio::sink::AudioSinkError;
 pub use traits::*;
 
 use std::ops::Deref;
@@ -57,7 +58,7 @@ pub trait Backend: Send + Sync {
         &self,
         id: &ClientContextId,
         options: AudioContextOptions,
-    ) -> Arc<Mutex<AudioContext>>;
+    ) -> Result<Arc<Mutex<AudioContext>>, AudioSinkError>;
     fn create_webrtc(&self, signaller: Box<dyn WebRtcSignaller>) -> WebRtcController;
     fn can_play_type(&self, media_type: &str) -> SupportsMediaType;
     fn set_capture_mocking(&self, _mock: bool) {}


### PR DESCRIPTION
Part of https://github.com/servo/servo/issues/32986, in order to handle errors in Servo, we need to remove panics and return errors.