### PR TITLE
Make ServoMedia::get infallible

### DIFF
--- a/examples/audio_decoder.rs
+++ b/examples/audio_decoder.rs
@@ -86,9 +86,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!()
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
+
 }

--- a/examples/audioinput_stream.rs
+++ b/examples/audioinput_stream.rs
@@ -17,9 +17,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/biquad.rs
+++ b/examples/biquad.rs
@@ -65,9 +65,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/channels.rs
+++ b/examples/channels.rs
@@ -53,9 +53,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/channelsum.rs
+++ b/examples/channelsum.rs
@@ -64,9 +64,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/constant_source.rs
+++ b/examples/constant_source.rs
@@ -91,9 +91,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/dummy.rs
+++ b/examples/dummy.rs
@@ -6,5 +6,5 @@ use servo_media_dummy::DummyBackend;
 
 fn main() {
     ServoMedia::init::<DummyBackend>();
-    ServoMedia::get().expect("couldn't create a dummy backend?");
+    ServoMedia::get();
 }

--- a/examples/iir_filter.rs
+++ b/examples/iir_filter.rs
@@ -76,9 +76,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/media_element_source_node.rs
+++ b/examples/media_element_source_node.rs
@@ -314,9 +314,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/muted_audiocontext.rs
+++ b/examples/muted_audiocontext.rs
@@ -82,9 +82,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/muted_player.rs
+++ b/examples/muted_player.rs
@@ -127,7 +127,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/offline_context.rs
+++ b/examples/offline_context.rs
@@ -76,9 +76,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!()
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/oscillator.rs
+++ b/examples/oscillator.rs
@@ -126,9 +126,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/panner.rs
+++ b/examples/panner.rs
@@ -176,9 +176,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/params.rs
+++ b/examples/params.rs
@@ -98,9 +98,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/params_connect.rs
+++ b/examples/params_connect.rs
@@ -53,9 +53,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/params_connect2.rs
+++ b/examples/params_connect2.rs
@@ -53,9 +53,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/params_settarget.rs
+++ b/examples/params_settarget.rs
@@ -62,9 +62,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -86,9 +86,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/play_media_stream.rs
+++ b/examples/play_media_stream.rs
@@ -83,7 +83,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/play_noise.rs
+++ b/examples/play_noise.rs
@@ -50,9 +50,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!()
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/player/app.rs
+++ b/examples/player/app.rs
@@ -184,8 +184,7 @@ impl App {
 
         // player
         let (player_event_sender, player_event_receiver) = ipc::channel::<player::PlayerEvent>()?;
-        let servo_media =
-            ServoMedia::get().map_err(|error| MiscError(format!("Failed to get media backend: {error:?}")))?;
+        let servo_media = ServoMedia::get();
 
         let frame_renderer = if !opts.no_video {
             Some(Arc::new(Mutex::new(MediaFrameRenderer::new(

--- a/examples/set_value_curve.rs
+++ b/examples/set_value_curve.rs
@@ -84,9 +84,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -167,7 +167,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/simple_webrtc.rs
+++ b/examples/simple_webrtc.rs
@@ -399,9 +399,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/stereo_panner.rs
+++ b/examples/stereo_panner.rs
@@ -54,9 +54,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/stream_dest_node.rs
+++ b/examples/stream_dest_node.rs
@@ -41,9 +41,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/stream_reader_node.rs
+++ b/examples/stream_reader_node.rs
@@ -26,9 +26,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/videoinput_stream.rs
+++ b/examples/videoinput_stream.rs
@@ -17,9 +17,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/examples/wave_shaper.rs
+++ b/examples/wave_shaper.rs
@@ -94,9 +94,6 @@ fn run_example(servo_media: Arc<ServoMedia>) {
 
 fn main() {
     ServoMedia::init::<servo_media_auto::Backend>();
-    if let Ok(servo_media) = ServoMedia::get() {
-        run_example(servo_media);
-    } else {
-        unreachable!();
-    }
+    let servo_media = ServoMedia::get();
+    run_example(servo_media);
 }

--- a/servo-media/lib.rs
+++ b/servo-media/lib.rs
@@ -106,8 +106,8 @@ impl ServoMedia {
         thread::spawn(move || INSTANCE.get_or_init(|| Arc::new(ServoMedia(backend_factory()))));
     }
 
-    pub fn get() -> Result<Arc<ServoMedia>, ()> {
-        Ok(INSTANCE.wait().clone())
+    pub fn get() -> Arc<ServoMedia> {
+        INSTANCE.wait().clone()
     }
 }
 


### PR DESCRIPTION
It was already infallible before, but returned
a Result type for unknown reasons. The relevant
Code hasn't been touched for 7 years.

I think the original intention was to make backend *creation* fallible, but as mentioned before
it currently isn't. And even if it *were* fallible it seems more reasonable to return a Result from
ServoMedia::init instead.