### PR TITLE
Remove dependency on `lazy_static`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,7 +2545,6 @@ dependencies = [
  "gstreamer-video",
  "gstreamer-webrtc",
  "ipc-channel",
- "lazy_static",
  "log 0.4.17",
  "mime 0.3.17",
  "once_cell",
@@ -2613,7 +2612,6 @@ dependencies = [
 name = "servo-media-streams"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "uuid",
 ]
 
@@ -2625,7 +2623,6 @@ version = "0.1.0"
 name = "servo-media-webrtc"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "log 0.4.17",
  "servo-media-streams",
  "uuid",

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -23,7 +23,6 @@ gst-webrtc = { workspace = true }
 gst-sdp = { workspace = true }
 gstreamer-sys = { workspace = true }
 ipc-channel = { workspace = true }
-lazy_static = "1.2.0"
 log = "0.4"
 mime = "0.3.13"
 once_cell = "1.18.0"

--- a/streams/Cargo.toml
+++ b/streams/Cargo.toml
@@ -10,5 +10,4 @@ name = "servo_media_streams"
 path = "lib.rs"
 
 [dependencies]
-lazy_static = "1.0"
 uuid = { version = "1.4", features = ["v4"] }

--- a/streams/lib.rs
+++ b/streams/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 pub mod capture;
 pub mod device_monitor;
 pub mod registry;

--- a/streams/registry.rs
+++ b/streams/registry.rs
@@ -1,12 +1,13 @@
 use super::MediaStream;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use uuid::Uuid;
 
-lazy_static! {
-    static ref MEDIA_STREAMS_REGISTRY: Mutex<HashMap<MediaStreamId, Arc<Mutex<dyn MediaStream>>>> =
-        Mutex::new(HashMap::new());
-}
+type RegisteredMediaStream = Arc<Mutex<dyn MediaStream>>;
+
+static MEDIA_STREAMS_REGISTRY: LazyLock<Mutex<HashMap<MediaStreamId, RegisteredMediaStream>>> = LazyLock::new(|| {
+    Mutex::new(HashMap::new())
+});
 
 #[derive(Clone, Copy, Hash, Eq, PartialEq)]
 pub struct MediaStreamId(Uuid);

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -9,8 +9,7 @@ edition = "2021"
 path = "lib.rs"
 
 [dependencies]
-lazy_static = "1.0"
-log = "0.4.6"
+log = "0.4"
 uuid = { version = "1.4", features = ["v4"] }
 
 [dependencies.servo-media-streams]


### PR DESCRIPTION
The gstreamer/webrtc crates were depending
    on lazy_static, but not using it.
    
In the case of the streams crate, lazy_static
can be replaced by the LazyLock struct from
    the standard library.
    (https://doc.rust-lang.org/std/sync/struct.LazyLock.html)