### PR TITLE
extend player api to support seekable

### DIFF
--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -184,6 +184,9 @@ impl Player for DummyPlayer {
     fn buffered(&self) -> Result<Vec<Range<f64>>, PlayerError> {
         Ok(vec![])
     }
+    fn seekable(&self) -> Result<Vec<Range<f64>>, PlayerError> {
+        Ok(vec![])
+    }
 
     fn set_stream(&self, _: &MediaStreamId, _: bool) -> Result<(), PlayerError> {
         Ok(())

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -94,6 +94,7 @@ pub trait Player: Send + MediaInstance {
     fn pause(&self) -> Result<(), PlayerError>;
     fn stop(&self) -> Result<(), PlayerError>;
     fn seek(&self, time: f64) -> Result<(), PlayerError>;
+    fn seekable(&self) -> Result<Vec<Range<f64>>, PlayerError>;
     fn set_mute(&self, val: bool) -> Result<(), PlayerError>;
     fn set_volume(&self, value: f64) -> Result<(), PlayerError>;
     fn set_input_size(&self, size: u64) -> Result<(), PlayerError>;


### PR DESCRIPTION
extend player trait to have `fn seekable()`
if the source is `StreamType::Seekable` return its duration, else return `buffered` ranges.
related [spec](https://html.spec.whatwg.org/multipage/media.html#dom-media-seekable), 

Related Issue: https://github.com/servo/servo/issues/22297