### PR TITLE
Fix a couple clippy warnings

### DIFF
--- a/audio/block.rs
+++ b/audio/block.rs
@@ -204,7 +204,7 @@ impl Block {
         self.channels
     }
 
-    pub fn iter(&mut self) -> FrameIterator {
+    pub fn iter(&mut self) -> FrameIterator<'_> {
         FrameIterator::new(self)
     }
 

--- a/audio/context.rs
+++ b/audio/context.rs
@@ -122,7 +122,7 @@ pub struct AudioContext {
     /// representing the final destination for all audio.
     dest_node: NodeId,
     listener: NodeId,
-    make_decoder: Arc<(dyn Fn() -> Box<dyn AudioDecoder> + Sync + Send)>,
+    make_decoder: Arc<dyn Fn() -> Box<dyn AudioDecoder> + Sync + Send>,
 }
 
 impl AudioContext {

--- a/audio/graph.rs
+++ b/audio/graph.rs
@@ -499,7 +499,7 @@ impl AudioGraph {
     }
 
     /// Obtain a mutable reference to a node
-    pub(crate) fn node_mut(&self, ix: NodeId) -> RefMut<Box<dyn AudioNodeEngine>> {
+    pub(crate) fn node_mut(&self, ix: NodeId) -> RefMut<'_, Box<dyn AudioNodeEngine>> {
         self.graph[ix.0].node.borrow_mut()
     }
 }


### PR DESCRIPTION
These currently make compiling servo with a local media version more annoying than it needs to be.

There is one warning left about a Signal Adapter that is never read, but I think that's directly related to https://github.com/servo/media/issues/440 so i didn't touch it for now.