### PR TITLE
gstreamer: Use weak ptr to renderer in sink callbacks

### DIFF
--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -641,7 +641,7 @@ impl GStreamerPlayer {
                     if let Some(video_renderer) = weak_video_renderer.upgrade() {
                         video_renderer.lock().unwrap().render(frame);
                     } else {
-                        return Err(gst::FlowError::Error);
+                        return Err(gst::FlowError::Flushing);
                     };
 
                     let _ = notify!(observer, PlayerEvent::VideoFrameUpdated);


### PR DESCRIPTION
Passing weak pointers to the audio/video renderer in the audio/video sink callbacks to exclude circular references which will allow to release the high level renderer and it's associated resources (audio buffers and video frames).

Fixes (partially): https://github.com/servo/servo/issues/43387