### PR TITLE
Pass precise position timestamp within `PlayerEvent`

### DIFF
--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -581,7 +581,7 @@ impl GStreamerPlayer {
         let observer = self.observer.clone();
         // Handle `position-update` signal.
         signal_adapter.connect_position_updated(move |_, position| {
-            if let Some(seconds) = position.map(|p| p.seconds()) {
+            if let Some(seconds) = position.map(|p| p.seconds_f64()) {
                 let _ = notify!(observer, PlayerEvent::PositionChanged(seconds));
             }
         });
@@ -589,7 +589,7 @@ impl GStreamerPlayer {
         let observer = self.observer.clone();
         // Handle `seek-done` signal.
         signal_adapter.connect_seek_done(move |_, position| {
-            let _ = notify!(observer, PlayerEvent::SeekDone(position.seconds()));
+            let _ = notify!(observer, PlayerEvent::SeekDone(position.seconds_f64()));
         });
 
         // Handle `media-info-updated` signal.

--- a/examples/muted_player.rs
+++ b/examples/muted_player.rs
@@ -107,11 +107,11 @@ fn run_example(servo_media: Arc<ServoMedia>) {
             },
             PlayerEvent::VideoFrameUpdated => eprint!("."),
             PlayerEvent::PositionChanged(p) => {
-                if p == 2 && !muted {
+                if p as u64 == 2 && !muted {
                     println!("\nPosition is at 2sec, muting, 1 second of silence incoming");
                     servo_media.mute(&context_id, true);
                     muted = true;
-                } else if p == 3 && muted {
+                } else if p as u64 == 3 && muted {
                     println!("\nPosition is at 3sec, unmuting");
                     servo_media.mute(&context_id, false);
                     muted = false;

--- a/examples/play_media_stream.rs
+++ b/examples/play_media_stream.rs
@@ -62,7 +62,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
             },
             PlayerEvent::VideoFrameUpdated => eprint!("."),
             PlayerEvent::PositionChanged(p) => {
-                if p == 4 {
+                if p as u64 == 4 {
                     break;
                 }
                 println!("Position changed {:?}", p)

--- a/examples/player/app.rs
+++ b/examples/player/app.rs
@@ -437,7 +437,7 @@ pub fn main_loop(mut app: App) -> Result<glutin::WindowedContext<glutin::Possibl
                     }
                 },
                 player::PlayerEvent::VideoFrameUpdated => frameupdated = true,
-                player::PlayerEvent::PositionChanged(pos) => playerstate.pos = pos as f64,
+                player::PlayerEvent::PositionChanged(pos) => playerstate.pos = pos,
                 _ => (),
             }
         }

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -141,7 +141,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
             PlayerEvent::VideoFrameUpdated => eprint!("."),
             PlayerEvent::PositionChanged(p) => {
                 let player = player.lock().unwrap();
-                if p == 4 && !seek_requested {
+                if p as u64 == 4 && !seek_requested {
                     println!("\nPosition changed to 4sec, seeking back to 0sec");
                     if let Err(e) = player.seek(0.) {
                         eprintln!("{:?}", e);

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -69,15 +69,15 @@ pub enum PlayerEvent {
     /// The internal player queue is running out of data. The client should start
     /// pushing more data.
     NeedData,
-    PositionChanged(u64),
-    /// The player needs the data to perform a seek to the given offset.
+    PositionChanged(f64),
+    /// The player needs the data to perform a seek to the given offset in bytes.
     /// The next push_data should get the buffers from the new offset.
     /// The player will be blocked until the user unlocks it through
     /// the given SeekLock instance.
     /// This event is only received for seekable stream types.
     SeekData(u64, SeekLock),
-    /// The player has performed a seek to the given offset.
-    SeekDone(u64),
+    /// The player has performed a seek to the given time offset in seconds.
+    SeekDone(f64),
     StateChanged(PlaybackState),
 }
 


### PR DESCRIPTION
The following `PlayerEvent::PositionChanged/SeekDone` events should contains the precise position timestamps to pass them to back to client, otherwise there are no possibility to identify timestamp changes between two `PositionChanged` events on the client side.

gst (5.104499333) -> servo (5)
gst (5.153333333) -> servo (5)