### PR TITLE
Add new `PlayerEvent::DurationChanged` event

### DIFF
--- a/docs/avplayback.md
+++ b/docs/avplayback.md
@@ -74,6 +74,9 @@ while let Ok(event) = receiver.recv() {
         PlayerEvent::MetadataUpdated(ref m) => {
             println!("\nMetadata updated! {:?}", m);
         }
+        PlayerEvent::DurationChanged(d) => {
+            println!("\nDuration changed! {:?}", d);
+        },
         PlayerEvent::StateChanged(ref s) => {
             println!("\nPlayer state changed to {:?}", s);
         }

--- a/examples/media_element_source_node.rs
+++ b/examples/media_element_source_node.rs
@@ -292,6 +292,9 @@ fn run_example(servo_media: Arc<ServoMedia>) {
             PlayerEvent::MetadataUpdated(ref m) => {
                 println!("\nMetadata updated! {:?}", m);
             },
+            PlayerEvent::DurationChanged(d) => {
+                println!("\nDuration changed! {:?}", d);
+            },
             PlayerEvent::StateChanged(ref s) => {
                 println!("\nPlayer state changed to {:?}", s);
             },

--- a/examples/muted_player.rs
+++ b/examples/muted_player.rs
@@ -102,6 +102,9 @@ fn run_example(servo_media: Arc<ServoMedia>) {
             PlayerEvent::MetadataUpdated(ref m) => {
                 println!("\nMetadata updated! {:?}", m);
             },
+            PlayerEvent::DurationChanged(d) => {
+                println!("\nDuration changed! {:?}", d);
+            },
             PlayerEvent::StateChanged(ref s) => {
                 println!("\nPlayer state changed to {:?}", s);
             },

--- a/examples/play_media_stream.rs
+++ b/examples/play_media_stream.rs
@@ -57,6 +57,9 @@ fn run_example(servo_media: Arc<ServoMedia>) {
             PlayerEvent::MetadataUpdated(ref m) => {
                 println!("\nMetadata updated! {:?}", m);
             },
+            PlayerEvent::DurationChanged(d) => {
+                println!("\nDuration changed! {:?}", d);
+            },
             PlayerEvent::StateChanged(ref s) => {
                 println!("\nPlayer state changed to {:?}", s);
             },

--- a/examples/player/app.rs
+++ b/examples/player/app.rs
@@ -383,12 +383,14 @@ pub fn main_loop(mut app: App) -> Result<glutin::WindowedContext<glutin::Possibl
                 player::PlayerEvent::EndOfStream => running = false,
                 player::PlayerEvent::Error(ref s) => Err(SMError(format!("{:?}", s)))?,
                 player::PlayerEvent::MetadataUpdated(metadata) => {
-                    println!("{:?}", metadata);
-                    if let Some(duration) = metadata.duration {
-                        playerstate.duration = duration.as_secs() as f64;
-                    } else {
-                        playerstate.duration = std::f64::INFINITY;
-                    }
+                    println!("Metadata updated to {:?}", metadata);
+                    playerstate.duration =
+                        duration.map_or(std::f64::INFINITY, |duration| duration.as_secs_f64());
+                },
+                PlayerEvent::DurationChanged(duration) => {
+                    println!("Duration changed to {:?}", duration);
+                    playerstate.duration =
+                        duration.map_or(std::f64::INFINITY, |duration| duration.as_secs_f64());
                 },
                 player::PlayerEvent::StateChanged(state) => {
                     println!("Player state changed to {:?}", state);

--- a/examples/simple_player.rs
+++ b/examples/simple_player.rs
@@ -135,6 +135,9 @@ fn run_example(servo_media: Arc<ServoMedia>) {
             PlayerEvent::MetadataUpdated(ref m) => {
                 println!("\nMetadata updated! {:?}", m);
             },
+            PlayerEvent::DurationChanged(d) => {
+                println!("\nDuration changed! {:?}", d);
+            },
             PlayerEvent::StateChanged(ref s) => {
                 println!("\nPlayer state changed to {:?}", s);
             },

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -1,3 +1,6 @@
+use std::ops::Range;
+use std::time::Duration;
+
 pub extern crate ipc_channel;
 #[macro_use]
 extern crate serde_derive;
@@ -11,7 +14,6 @@ pub mod video;
 
 use ipc_channel::ipc::{self, IpcSender};
 use servo_media_traits::MediaInstance;
-use std::ops::Range;
 use streams::registry::MediaStreamId;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -66,6 +68,8 @@ pub enum PlayerEvent {
     Error(String),
     VideoFrameUpdated,
     MetadataUpdated(metadata::Metadata),
+    // The `None` value means the duration is unknown, in which case this is likely a live stream.
+    DurationChanged(Option<Duration>),
     /// The internal player queue is running out of data. The client should start
     /// pushing more data.
     NeedData,


### PR DESCRIPTION
The goal is to add a new event that allows the client to easily handle changes of the media stream's duration (sometimes duration could be imprecise or even identify with significant delay by media engine). Otherwise, the client must distinguish between consecutive `MetadataUpdate` events that differ only in the `duration` element, and handling them with different conditions (example HTMLMediaElement).

After this change will be  the following
`gstbin state - gstplay signal - event` sequence:
- new metadata  -> `media_info_updated` ->  `MetadataUpdate` event
- new duration -> `duration_changed` + `media_info_updated` -> `DurationChanged` event + Nothing (already ignored)

Fixes (partially): https://github.com/servo/servo/issues/40626