### PR TITLE
Return an empty slice on safe slice casting error

### DIFF
--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -100,7 +100,7 @@ fn metadata_from_media_info(media_info: &gst_play::PlayMediaInfo) -> Result<Meta
 pub struct GStreamerAudioChunk(gst::buffer::MappedBuffer<gst::buffer::Readable>);
 impl AsRef<[f32]> for GStreamerAudioChunk {
     fn as_ref(&self) -> &[f32] {
-        self.0.as_ref().as_slice_of::<f32>().unwrap()
+        self.0.as_ref().as_slice_of::<f32>().unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
The cargo `byte-slice-cast` crate supports safe `u8 -> f32` slice casting through the `as_slice_of` trait function. However, for dynamic linked crate from rust toolchain (`byte-slice-cast-0.2.0`) in case if source `u8` slice is empty, the `WrongAlignment` error will be returned, so need to handle this edge case properly and return the empty `f32` slice on error.

Please notice that the newest version (`byte-slice-cast-1.2.3`) is handling this case without alignment error (return an empty slice).

https://docs.rs/byte-slice-cast/0.2.0/src/byte_slice_cast/lib.rs.html#206
https://docs.rs/byte-slice-cast/1.2.3/src/byte_slice_cast/lib.rs.html#263