### PR TITLE
Suppress warning about field that's not read.

### DIFF
--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -112,7 +112,7 @@ enum PlayerSource {
 
 struct PlayerInner {
     player: gst_play::Play,
-    signal_adapter: gst_play::PlaySignalAdapter,
+    _signal_adapter: gst_play::PlaySignalAdapter,
     source: Option<PlayerSource>,
     video_sink: gst_app::AppSink,
     input_size: u64,
@@ -538,7 +538,7 @@ impl GStreamerPlayer {
 
         *self.inner.borrow_mut() = Some(Arc::new(Mutex::new(PlayerInner {
             player,
-            signal_adapter: signal_adapter.clone(),
+            _signal_adapter: signal_adapter.clone(),
             source: None,
             video_sink,
             input_size: 0,


### PR DESCRIPTION
I'm not yet sure if we need to store it or not, so let's at least clean up the warning in the meantime.