### PR TITLE
Make the media player API more statefull

### DIFF
--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -154,6 +154,11 @@ impl Player for DummyPlayer {
     fn pause(&self) -> Result<(), PlayerError> {
         Ok(())
     }
+
+    fn paused(&self) -> bool {
+        true
+    }
+
     fn stop(&self) -> Result<(), PlayerError> {
         Ok(())
     }
@@ -165,27 +170,43 @@ impl Player for DummyPlayer {
         Ok(())
     }
 
+    fn muted(&self) -> bool {
+        false
+    }
+
     fn set_volume(&self, _: f64) -> Result<(), PlayerError> {
         Ok(())
+    }
+
+    fn volume(&self) -> f64 {
+        1.0
     }
 
     fn set_input_size(&self, _: u64) -> Result<(), PlayerError> {
         Ok(())
     }
-    fn set_rate(&self, _: f64) -> Result<(), PlayerError> {
+
+    fn set_playback_rate(&self, _: f64) -> Result<(), PlayerError> {
         Ok(())
     }
+
+    fn playback_rate(&self) -> f64 {
+        1.0
+    }
+
     fn push_data(&self, _: Vec<u8>) -> Result<(), PlayerError> {
         Ok(())
     }
     fn end_of_stream(&self) -> Result<(), PlayerError> {
         Ok(())
     }
-    fn buffered(&self) -> Result<Vec<Range<f64>>, PlayerError> {
-        Ok(vec![])
+
+    fn buffered(&self) -> Vec<Range<f64>> {
+        vec![]
     }
-    fn seekable(&self) -> Result<Vec<Range<f64>>, PlayerError> {
-        Ok(vec![])
+
+    fn seekable(&self) -> Vec<Range<f64>> {
+        vec![]
     }
 
     fn set_stream(&self, _: &MediaStreamId, _: bool) -> Result<(), PlayerError> {

--- a/backends/ohos/player.rs
+++ b/backends/ohos/player.rs
@@ -36,6 +36,10 @@ impl Player for OhosAVPlayer {
         todo!()
     }
 
+    fn paused(&self) -> bool {
+        todo!()
+    }
+
     fn stop(&self) -> Result<(), servo_media_player::PlayerError> {
         todo!()
     }
@@ -44,15 +48,23 @@ impl Player for OhosAVPlayer {
         todo!()
     }
 
-    fn seekable(&self) -> Result<Vec<std::ops::Range<f64>>, servo_media_player::PlayerError> {
+    fn seekable(&self) -> Vec<std::ops::Range<f64>> {
         todo!()
     }
 
-    fn set_mute(&self, val: bool) -> Result<(), servo_media_player::PlayerError> {
+    fn set_mute(&self, muted: bool) -> Result<(), servo_media_player::PlayerError> {
         todo!()
     }
 
-    fn set_volume(&self, value: f64) -> Result<(), servo_media_player::PlayerError> {
+    fn muted(&self) -> bool {
+        todo!()
+    }
+
+    fn set_volume(&self, volume: f64) -> Result<(), servo_media_player::PlayerError> {
+        todo!()
+    }
+
+    fn volume(&self) -> f64 {
         todo!()
     }
 
@@ -60,7 +72,11 @@ impl Player for OhosAVPlayer {
         todo!()
     }
 
-    fn set_rate(&self, rate: f64) -> Result<(), servo_media_player::PlayerError> {
+    fn set_playback_rate(&self, playback_rate: f64) -> Result<(), servo_media_player::PlayerError> {
+        todo!()
+    }
+
+    fn playback_rate(&self) -> f64 {
         todo!()
     }
 
@@ -72,7 +88,7 @@ impl Player for OhosAVPlayer {
         todo!()
     }
 
-    fn buffered(&self) -> Result<Vec<std::ops::Range<f64>>, servo_media_player::PlayerError> {
+    fn buffered(&self) -> Vec<std::ops::Range<f64>> {
         todo!()
     }
 

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -96,17 +96,21 @@ pub enum StreamType {
 pub trait Player: Send + MediaInstance {
     fn play(&self) -> Result<(), PlayerError>;
     fn pause(&self) -> Result<(), PlayerError>;
+    fn paused(&self) -> bool;
     fn stop(&self) -> Result<(), PlayerError>;
     fn seek(&self, time: f64) -> Result<(), PlayerError>;
-    fn seekable(&self) -> Result<Vec<Range<f64>>, PlayerError>;
-    fn set_mute(&self, val: bool) -> Result<(), PlayerError>;
-    fn set_volume(&self, value: f64) -> Result<(), PlayerError>;
+    fn seekable(&self) -> Vec<Range<f64>>;
+    fn set_mute(&self, muted: bool) -> Result<(), PlayerError>;
+    fn muted(&self) -> bool;
+    fn set_volume(&self, volume: f64) -> Result<(), PlayerError>;
+    fn volume(&self) -> f64;
     fn set_input_size(&self, size: u64) -> Result<(), PlayerError>;
-    fn set_rate(&self, rate: f64) -> Result<(), PlayerError>;
+    fn set_playback_rate(&self, playback_rate: f64) -> Result<(), PlayerError>;
+    fn playback_rate(&self) -> f64;
     fn push_data(&self, data: Vec<u8>) -> Result<(), PlayerError>;
     fn end_of_stream(&self) -> Result<(), PlayerError>;
     /// Get the list of time ranges in seconds that have been buffered.
-    fn buffered(&self) -> Result<Vec<Range<f64>>, PlayerError>;
+    fn buffered(&self) -> Vec<Range<f64>>;
     /// Set the stream to be played by the player.
     /// Only a single stream of the same type (audio or video) can be set.
     /// Subsequent calls with a stream of the same type will override the previously


### PR DESCRIPTION
New media player APIs (`paused`, `playback_rate`, `volume`) were added to track the current associated state to
reduce overhead of the media backend state changes.
    
The `setter` methods will return `Result<T, PlayerError>` while the `getter` methods - T (default value on media error).
    
Note that handling the playback rate change it quite tricky for gsteamer backend (need to wait until GST_STATE_PAUSED).
    
The `gst_play_set_rate` function not only sets the playback rate property in GstPlay but also creates a new `seek` request with the current position, then fires `seek done` event afterwards and changes the state to `PlayState::Paused`.
    
There are client application requirement to send `PlayerEvent::Paused` event after receiving the initial metadata, so the `send_paused_event` workaround has been added to the gstreamer backend for other cases.
https://github.com/servo/servo/issues/40740
