### PR TITLE
gst: Use buffered ranges with precise position timestamps

### DIFF
--- a/backends/gstreamer/player.rs
+++ b/backends/gstreamer/player.rs
@@ -255,14 +255,14 @@ impl PlayerInner {
                             start.unwrap()
                         } else {
                             gst::format::Percent::from_percent(0)
-                        } * duration.as_secs() as u32
-                            / gst::format::Percent::MAX) as f64;
+                        } / gst::format::Percent::MAX) as f64
+                            * duration.as_secs_f64();
                         let end = (if let gst::GenericFormattedValue::Percent(end) = end {
                             end.unwrap()
                         } else {
                             gst::format::Percent::from_percent(0)
-                        } * duration.as_secs() as u32
-                            / gst::format::Percent::MAX) as f64;
+                        } / gst::format::Percent::MAX) as f64
+                            * duration.as_secs_f64();
                         result.push(Range { start, end });
                     }
                 }

--- a/examples/player/app.rs
+++ b/examples/player/app.rs
@@ -384,8 +384,9 @@ pub fn main_loop(mut app: App) -> Result<glutin::WindowedContext<glutin::Possibl
                 player::PlayerEvent::Error(ref s) => Err(SMError(format!("{:?}", s)))?,
                 player::PlayerEvent::MetadataUpdated(metadata) => {
                     println!("Metadata updated to {:?}", metadata);
-                    playerstate.duration =
-                        metadata.duration.map_or(std::f64::INFINITY, |duration| duration.as_secs_f64());
+                    playerstate.duration = metadata
+                        .duration
+                        .map_or(std::f64::INFINITY, |duration| duration.as_secs_f64());
                 },
                 player::PlayerEvent::DurationChanged(duration) => {
                     println!("Duration changed to {:?}", duration);


### PR DESCRIPTION
Buffered ranges from the gstreamer backend must contain the precise position timestamps (not rounded to the nearest second).

Continuation https://github.com/servo/media/pull/460