### PR TITLE
GStreamerPlayer should resume playback only if it was playing on suspend

### DIFF
--- a/backends/dummy/lib.rs
+++ b/backends/dummy/lib.rs
@@ -158,6 +158,9 @@ impl Player for DummyPlayer {
     fn paused(&self) -> bool {
         true
     }
+    fn can_resume(&self) -> bool {
+        true
+    }
 
     fn stop(&self) -> Result<(), PlayerError> {
         Ok(())

--- a/player/lib.rs
+++ b/player/lib.rs
@@ -97,6 +97,7 @@ pub trait Player: Send + MediaInstance {
     fn play(&self) -> Result<(), PlayerError>;
     fn pause(&self) -> Result<(), PlayerError>;
     fn paused(&self) -> bool;
+    fn can_resume(&self) -> bool;
     fn stop(&self) -> Result<(), PlayerError>;
     fn seek(&self, time: f64) -> Result<(), PlayerError>;
     fn seekable(&self) -> Vec<Range<f64>>;


### PR DESCRIPTION
GStreamerPlayer should resume playback only if it was playing on suspend

Fixes https://github.com/servo/media/issues/480 and https://github.com/servo/servo/issues/41281.

## Testing:

### Test case 1: does not resume if it was not playing on suspend

```
<!doctype html>
<audio preload="auto" networkstate="0"><source src="https://fairysvoice.net/games/Fire_Triss/html5game/an1.mp3" type="audio/mp3"></audio>
<a href="https://example.org">CLICK THIS THEN GO BACK</a>
```

Steps:
- Music should not be playing when the page loads.
- Click the link, then hit the back button.
- Music should not be playing.

### Test case 2: resumes if it was playing on suspend

```
<!doctype html>
<audio preload="auto" autoplay="true"><source src="https://fairysvoice.net/games/Fire_Triss/html5game/an1.mp3" type="audio/mp3"></audio>
<a href="https://example.org">CLICK THIS THEN GO BACK</a>
```

Steps:
- Music should be playing when the page loads.
- Click the link, then hit the back button.
- Music should resume playing.
